### PR TITLE
feat(ui): tabbed QLoRA control board + saved config & monitor

### DIFF
--- a/packages/app/src/components/settings-qlora.tsx
+++ b/packages/app/src/components/settings-qlora.tsx
@@ -1,0 +1,801 @@
+import {
+  type Component,
+  Show,
+  For,
+  createEffect,
+  createMemo,
+  createResource,
+  onCleanup,
+  createSignal,
+  onMount,
+} from "solid-js"
+import { createStore } from "solid-js/store"
+import { Button } from "@openhei-ai/ui/button"
+import { Icon } from "@openhei-ai/ui/icon"
+import { Popover } from "@openhei-ai/ui/popover"
+import { Select } from "@openhei-ai/ui/select"
+import { Switch } from "@openhei-ai/ui/switch"
+import { TextField } from "@openhei-ai/ui/text-field"
+import { showToast } from "@openhei-ai/ui/toast"
+import { useSettings } from "@/context/settings"
+
+type Doctor = {
+  installed: boolean
+  tool_dir: string
+  python?: string
+  version?: string
+  gpu?: string
+  disk?: { path: string; free_bytes: number }
+  active?: { run_id: string; pid: number; started_at: string }
+}
+
+type Status = {
+  ok: boolean
+  run_id?: string
+  running: boolean
+  stage?: string
+  status?: Record<string, unknown>
+  ready?: Record<string, unknown>
+}
+
+const preset = {
+  safe: {
+    name: "Mistral-7B safe (11GB)",
+    base_model: "mistralai/Mistral-7B-Instruct-v0.2",
+    seq_len: 1024,
+    batch_size: 1,
+    grad_accum: 8,
+    lora_r: 32,
+    train_steps: 1200,
+    val_ratio: 0.05,
+    max_repos: 50,
+    rounds: 2,
+    samples_per_run: 100,
+    max_requests: 10_000,
+  },
+  smoke: {
+    name: "Mistral fast smoke",
+    base_model: "mistralai/Mistral-7B-Instruct-v0.2",
+    seq_len: 512,
+    batch_size: 1,
+    grad_accum: 4,
+    lora_r: 16,
+    train_steps: 50,
+    val_ratio: 0.05,
+    max_repos: 1,
+    rounds: 1,
+    samples_per_run: 10,
+    max_requests: 100,
+  },
+} as const
+
+async function get<T>(url: string): Promise<T> {
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(await res.text())
+  return (await res.json()) as T
+}
+
+async function post<T>(url: string, body: unknown): Promise<T> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) throw new Error(await res.text())
+  return (await res.json()) as T
+}
+
+export const SettingsQLoRA: Component = () => {
+  const settings = useSettings()
+  const [store, setStore] = createStore<any>({
+    preset: "safe" as keyof typeof preset,
+    teacher_model: "openai/gpt-5.2",
+    teacher_backend: "openhei" as "openhei" | "legacy",
+    teacher_workers: 1,
+    teacher_batch_size: 1,
+    teacher_max_tokens: 256,
+    openhei_attach: "http://127.0.0.1:4100",
+    openhei_agent: "",
+    openhei_start: true,
+    openhei_attach_strict: false,
+
+    stack: "python",
+    max_repos: preset.safe.max_repos,
+    rounds: preset.safe.rounds,
+    samples_per_run: preset.safe.samples_per_run,
+    max_requests: preset.safe.max_requests,
+
+    base_model: preset.safe.base_model,
+    train_steps: preset.safe.train_steps,
+    save_steps: 100,
+    eval_steps: 200,
+    seq_len: preset.safe.seq_len,
+    batch_size: preset.safe.batch_size,
+    grad_accum: preset.safe.grad_accum,
+    lora_r: preset.safe.lora_r,
+    val_ratio: preset.safe.val_ratio,
+
+    running: false,
+    run_id: "" as string,
+    stage: "" as string,
+    progress: undefined as undefined | { done: number; total: number; pct: number; rate: number; eta: number },
+    logs: [] as string[],
+  })
+
+  const [doc, docActions] = createResource(() => get<Doctor>("/api/v1/qlora/doctor"))
+  const [teachers] = createResource(() => get<{ models: string[] }>("/api/v1/qlora/teacher-models"))
+  const [bases] = createResource(() => get<{ models: string[] }>("/api/v1/qlora/base-models"))
+
+  // Saved config as returned from server (canonical). We keep it separate from the UI store
+  const [saved, setSaved] = createStore<Record<string, unknown>>({})
+  const [savedAt, setSavedAt] = createSignal<number | null>(null)
+
+  const activeTabs = ["Setup", "Models", "Data", "Training", "Budget", "Monitor", "Artifacts"] as const
+  const [activeTab, setActiveTab] = createSignal<(typeof activeTabs)[number]>("Setup")
+
+  const put = async <T,>(url: string, body: unknown): Promise<T> => {
+    const res = await fetch(url, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    })
+    if (!res.ok) throw new Error(await res.text())
+    return (await res.json()) as T
+  }
+
+  // Build a canonical config object from the local store (exclude runtime-only fields)
+  const configFromStore = () => ({
+    stack: store.stack,
+    max_repos: store.max_repos,
+    rounds: store.rounds,
+    samples_per_run: store.samples_per_run,
+    max_requests: store.max_requests,
+    base_model: store.base_model,
+    train_steps: store.train_steps,
+    save_steps: store.save_steps,
+    eval_steps: store.eval_steps,
+    seq_len: store.seq_len,
+    batch_size: store.batch_size,
+    grad_accum: store.grad_accum,
+    lora_r: store.lora_r,
+    val_ratio: store.val_ratio,
+    preset: store.preset,
+    teacher: {
+      teacher_backend: store.teacher_backend,
+      teacher_model: store.teacher_model,
+      teacher_workers: store.teacher_workers,
+      teacher_batch_size: store.teacher_batch_size,
+      teacher_max_tokens: store.teacher_max_tokens,
+      openhei_attach: store.openhei_attach,
+      openhei_agent: store.openhei_agent,
+      openhei_start: store.openhei_start,
+      openhei_attach_strict: store.openhei_attach_strict,
+    },
+  })
+
+  // Compare fields for dirty state. We map logical fields to tabs so we can show per-tab dirty badges.
+  const tabFields: Record<string, string[]> = {
+    Setup: [
+      "preset",
+      "stack",
+      "openhei_attach",
+      "openhei_agent",
+      "openhei_start",
+      "openhei_attach_strict",
+      "teacher_backend",
+    ],
+    Models: ["teacher_model", "base_model"],
+    Data: ["max_repos", "rounds", "samples_per_run"],
+    Training: ["train_steps", "save_steps", "eval_steps", "seq_len", "batch_size", "grad_accum", "lora_r", "val_ratio"],
+    Budget: ["teacher_workers", "teacher_batch_size", "teacher_max_tokens", "max_requests"],
+    Monitor: [],
+    Artifacts: ["save_steps"],
+  }
+
+  const isDirty = createMemo(() => {
+    try {
+      const a = JSON.stringify(configFromStore())
+      const b = JSON.stringify(saved)
+      return a !== b
+    } catch {
+      return false
+    }
+  })
+
+  const isTabDirty = (tab: string) => {
+    if (!saved || Object.keys(saved).length === 0) return false
+    const cfg = configFromStore()
+    for (const k of tabFields[tab] ?? []) {
+      const a = (cfg as any)[k]
+      const b = (saved as any)[k]
+      if (JSON.stringify(a) !== JSON.stringify(b)) return true
+    }
+    // teacher.* fields are nested
+    if (tab === "Setup") {
+      const t = (cfg as any).teacher || {}
+      const s = (saved as any).teacher || {}
+      for (const fk of [
+        "teacher_backend",
+        "openhei_attach",
+        "openhei_agent",
+        "openhei_start",
+        "openhei_attach_strict",
+      ]) {
+        const key = fk === "teacher_backend" ? "teacher_backend" : fk
+        if (JSON.stringify(t[key]) !== JSON.stringify(s[key])) return true
+      }
+    }
+    return false
+  }
+
+  const options = createMemo<Array<{ id: string; name: string }>>(() =>
+    Object.entries(preset).map(([id, item]) => ({ id, name: item.name })),
+  )
+
+  createEffect(() => {
+    const id = store.preset as keyof typeof preset
+    const p = preset[id]
+    setStore({
+      base_model: p.base_model,
+      seq_len: p.seq_len,
+      batch_size: p.batch_size,
+      grad_accum: p.grad_accum,
+      lora_r: p.lora_r,
+      train_steps: p.train_steps,
+      val_ratio: p.val_ratio,
+      max_repos: p.max_repos,
+      rounds: p.rounds,
+      samples_per_run: p.samples_per_run,
+      max_requests: p.max_requests,
+    })
+  })
+
+  let es: EventSource | undefined
+  const close = () => {
+    es?.close()
+    es = undefined
+  }
+  onCleanup(close)
+
+  const connect = (run_id: string) => {
+    close()
+    setStore("logs", [])
+    setStore("progress", undefined)
+    es = new EventSource(`/api/v1/qlora/logs?run_id=${encodeURIComponent(run_id)}`)
+    es.onmessage = (e) => {
+      const data = JSON.parse(e.data) as { type: string; [k: string]: unknown }
+      if (data.type === "progress") {
+        setStore("progress", {
+          done: Number(data.done),
+          total: Number(data.total),
+          pct: Number(data.pct),
+          rate: Number(data.rate),
+          eta: Number(data.eta),
+        })
+        return
+      }
+      if (data.type !== "log") return
+      const line = String(data.line ?? "")
+      setStore("logs", (prev: string[]) => {
+        const next = [...prev, line]
+        return next.length > 2000 ? next.slice(-2000) : next
+      })
+    }
+    es.onerror = () => {
+      // Allow automatic reconnect behavior from EventSource.
+    }
+  }
+
+  const poll = async (run_id: string) => {
+    const s = await get<Status>(`/api/v1/qlora/status?run_id=${encodeURIComponent(run_id)}`).catch(() => undefined)
+    if (!s) return
+    setStore("running", s.running)
+    setStore("stage", s.stage ?? "")
+    if (s.ready && !s.running) {
+      showToast({ variant: "success", icon: "circle-check", title: "READY", description: `Run ${run_id} complete` })
+    }
+  }
+
+  createEffect(() => {
+    const run_id = store.run_id
+    if (!run_id) return
+    let alive = true
+    const tick = () => {
+      if (!alive) return
+      void poll(run_id)
+    }
+    tick()
+    const t = setInterval(tick, 1500)
+    onCleanup(() => {
+      alive = false
+      clearInterval(t)
+    })
+  })
+
+  const install = async () => {
+    const out = await post<{ ok: boolean; message: string }>("/api/v1/qlora/install", {})
+    showToast({ title: out.ok ? "Installed" : "Install failed", description: out.message })
+    await docActions.refetch()
+  }
+
+  const start = async () => {
+    const d = doc.latest
+    if (!d?.installed) {
+      showToast({ title: "heidi-engine not installed", description: "Click Install first" })
+      return
+    }
+    // Start should use the last saved config by default. If there are unsaved changes, confirm run with unsaved
+    const cfg = saved && Object.keys(saved).length > 0 ? saved : configFromStore()
+    if (isDirty()) {
+      const ok = window.confirm(
+        "You have unsaved changes — start with unsaved changes? Click OK to proceed, or Cancel to save first.",
+      )
+      if (!ok) return
+    }
+
+    const out = await post<{ ok: boolean; run_id?: string; message: string }>("/api/v1/qlora/start", cfg)
+    if (!out.ok || !out.run_id) {
+      showToast({ title: "Start failed", description: out.message })
+      return
+    }
+    setStore("run_id", out.run_id)
+    setStore("running", true)
+    connect(out.run_id)
+  }
+
+  const stop = async () => {
+    const run_id = store.run_id
+    const out = await post<{ ok: boolean; message: string }>("/api/v1/qlora/stop", run_id ? { run_id } : {})
+    showToast({ title: out.ok ? "Stopped" : "Stop failed", description: out.message })
+    setStore("running", false)
+    close()
+    await docActions.refetch()
+  }
+
+  const info = createMemo(() => {
+    const d = doc.latest
+    if (!d) return
+    const parts = [`Installed: ${d.installed ? "yes" : "no"}`, `Tool dir: ${d.tool_dir}`]
+    if (d.version) parts.push(`heidi-engine: ${d.version}`)
+    if (d.gpu) parts.push(`GPU: ${d.gpu.split("\n")[0]}`)
+    if (d.disk) parts.push(`Disk free: ${Math.round(d.disk.free_bytes / 1024 / 1024 / 1024)} GB`)
+    return parts
+  })
+
+  const teacherOptions = createMemo(() => (teachers.latest?.models ?? []).map((id) => ({ id })))
+  const baseOptions = createMemo(() => {
+    const items = bases.latest?.models ?? []
+    const merged = [...new Set([store.base_model, ...items])].filter((x) => x)
+    return merged.map((id) => ({ id }))
+  })
+
+  // On mount: hydrate from localStorage then reconcile with server canonical config
+  onMount(async () => {
+    try {
+      const local = localStorage.getItem("qlora.config")
+      if (local) {
+        const parsed = JSON.parse(local)
+        // apply to store partial fields
+        setStore(parsed as any)
+      }
+    } catch {
+      // ignore parse errors
+    }
+    try {
+      const server = await get<Record<string, unknown>>("/api/v1/qlora/config")
+      setSaved(server)
+      setSavedAt(Date.now())
+      // merge canonical server config into UI store
+      const t = server.teacher as any
+      setStore((s: any) => ({
+        stack: (server as any).stack ?? s.stack,
+        max_repos: (server as any).max_repos ?? s.max_repos,
+        rounds: (server as any).rounds ?? s.rounds,
+        samples_per_run: (server as any).samples_per_run ?? s.samples_per_run,
+        max_requests: (server as any).max_requests ?? s.max_requests,
+        base_model: (server as any).base_model ?? s.base_model,
+        train_steps: (server as any).train_steps ?? s.train_steps,
+        save_steps: (server as any).save_steps ?? s.save_steps,
+        eval_steps: (server as any).eval_steps ?? s.eval_steps,
+        seq_len: (server as any).seq_len ?? s.seq_len,
+        batch_size: (server as any).batch_size ?? s.batch_size,
+        grad_accum: (server as any).grad_accum ?? s.grad_accum,
+        lora_r: (server as any).lora_r ?? s.lora_r,
+        val_ratio: (server as any).val_ratio ?? s.val_ratio,
+        preset: (server as any).preset ?? s.preset,
+        teacher_model: t?.teacher_model ?? s.teacher_model,
+        teacher_backend: t?.teacher_backend ?? s.teacher_backend,
+        teacher_workers: t?.teacher_workers ?? s.teacher_workers,
+        teacher_batch_size: t?.teacher_batch_size ?? s.teacher_batch_size,
+        teacher_max_tokens: t?.teacher_max_tokens ?? s.teacher_max_tokens,
+        openhei_attach: t?.openhei_attach ?? s.openhei_attach,
+        openhei_agent: t?.openhei_agent ?? s.openhei_agent,
+        openhei_start: t?.openhei_start ?? s.openhei_start,
+        openhei_attach_strict: t?.openhei_attach_strict ?? s.openhei_attach_strict,
+      }))
+    } catch (err) {
+      // ignore server errors — UI can still function with local values
+      console.warn("Failed to fetch qlora config", err)
+    }
+  })
+
+  const save = async () => {
+    try {
+      const cfg = configFromStore()
+      const out = await put<{ ok: boolean; message?: string; config?: Record<string, unknown> }>(
+        "/api/v1/qlora/config",
+        cfg,
+      )
+      setSaved(out.config ?? cfg)
+      setSavedAt(Date.now())
+      localStorage.setItem("qlora.config", JSON.stringify(out.config ?? cfg))
+      showToast({ title: "Saved", description: "QLoRA config saved" })
+    } catch (err: any) {
+      showToast({ title: "Save failed", description: String(err?.message ?? err) })
+    }
+  }
+
+  return (
+    <div class="flex flex-col h-full overflow-y-auto no-scrollbar px-4 pb-10 sm:px-10 sm:pb-10">
+      <div class="sticky top-0 z-10 bg-[linear-gradient(to_bottom,var(--surface-stronger-non-alpha)_calc(100%_-_24px),transparent)]">
+        <div class="flex flex-col gap-2 pt-6 pb-6 max-w-[900px]">
+          <h2 class="text-16-medium text-text-strong">QLoRA</h2>
+          <Show when={info()}>
+            {(x) => <div class="text-12-regular text-text-weak whitespace-pre-line">{x().join("\n")}</div>}
+          </Show>
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-8 max-w-[900px]">
+        <div class="bg-surface-raised-base px-4 rounded-lg">
+          <div class="flex items-center justify-between gap-4 py-3 border-b border-border-weak-base last:border-none">
+            <div class="flex flex-col gap-0.5 min-w-0">
+              <span class="text-14-medium text-text-strong">
+                <span class="inline-flex items-center gap-2">
+                  <span>Doctor</span>
+                  <Help text="Checks whether heidi-engine is installed and whether basic dependencies (GPU tools, disk space) look OK." />
+                </span>
+              </span>
+              <span class="text-12-regular text-text-weak">Detect pump + python + GPU</span>
+            </div>
+            <div class="flex items-center gap-2">
+              <Button size="small" variant="secondary" onClick={() => docActions.refetch()}>
+                Refresh
+              </Button>
+              <Button size="small" variant="secondary" onClick={install}>
+                Install
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <div class="bg-surface-raised-base px-4 rounded-lg">
+          <div class="flex items-center justify-between gap-4 py-3 border-b border-border-weak-base last:border-none">
+            <div class="flex items-center gap-2">
+              {activeTabs.map((t) => (
+                <button
+                  type="button"
+                  class={`px-3 py-1 rounded ${activeTab() === t ? "bg-surface-strong text-text-strong" : "text-text-weak hover:text-text-base"}`}
+                  onClick={() => setActiveTab(t)}
+                >
+                  {t}
+                  <Show when={isTabDirty(t)}>
+                    <span class="ml-2 inline-block w-2 h-2 rounded-full bg-red-500" />
+                  </Show>
+                </button>
+              ))}
+            </div>
+            <div class="flex items-center gap-2">
+              <div class="text-12-regular text-text-weak mr-2">
+                {savedAt() ? `Saved ${new Date(savedAt()!).toLocaleString()}` : "Not saved"}
+              </div>
+              <Button size="small" variant={isDirty() ? "primary" : "secondary"} disabled={!isDirty()} onClick={save}>
+                Save
+              </Button>
+            </div>
+          </div>
+
+          <Show when={activeTab() === "Setup"}>
+            <div>
+              <Row
+                title="Preset"
+                desc="Applies a bundle of recommended defaults for base model + training + collection."
+                help="Applies a bundle of recommended defaults for base model + training + collection."
+              >
+                <Select
+                  options={options()}
+                  current={options().find((x) => x.id === store.preset)}
+                  value={(x) => x.id}
+                  label={(x) => (x as any).name ?? (x as any).id}
+                  onSelect={(x) => x && setStore("preset", x.id as keyof typeof preset)}
+                  variant="secondary"
+                  size="small"
+                  triggerVariant="settings"
+                />
+              </Row>
+
+              <Row
+                title="Enabled"
+                desc="Show QLoRA in the left sidebar"
+                help="Shows a QLoRA entry in the left sidebar for quicker access."
+              >
+                <div data-action="settings-qlora-enabled">
+                  <Switch
+                    checked={settings.ml.qloraEnabled()}
+                    onChange={(checked) => settings.ml.setQLoRAEnabled(checked)}
+                  />
+                </div>
+              </Row>
+
+              <Row
+                title="Attach"
+                desc="OpenHei serve attach URL"
+                help="URL of the OpenHei server to attach to for Path-B teacher generation (used by heidi-engine)."
+              >
+                <TextField
+                  value={store.openhei_attach}
+                  onChange={(v) => setStore("openhei_attach", v)}
+                  class="w-[320px]"
+                />
+              </Row>
+
+              <Row
+                title="Stack"
+                desc="Execution stack"
+                help="Execution backend used to run heidi-engine (python/other)."
+              >
+                <Select
+                  options={[{ id: "python", name: "python" }]}
+                  current={{ id: store.stack }}
+                  value={(x) => x.id}
+                  label={(x) => (x as any).name ?? String((x as any).id)}
+                  onSelect={(x) => x && setStore("stack", x.id)}
+                  variant="secondary"
+                  size="small"
+                />
+              </Row>
+            </div>
+          </Show>
+
+          <Show when={activeTab() === "Models"}>
+            <div>
+              <Row
+                title="Teacher model"
+                desc="Path-B teacher for collection"
+                help="Model used to generate training samples. Faster/cheaper models collect quicker; stronger models can generate better samples."
+              >
+                <Select
+                  options={teacherOptions()}
+                  current={teacherOptions().find((x) => x.id === store.teacher_model)}
+                  value={(x) => x.id}
+                  label={(x) => x.id}
+                  onSelect={(x) => x && setStore("teacher_model", x.id)}
+                  class="w-[320px] max-w-full"
+                  variant="secondary"
+                  size="small"
+                  triggerVariant="settings"
+                />
+              </Row>
+
+              <Row
+                title="Base model"
+                desc="HF base model for QLoRA"
+                help="Hugging Face base model to fine-tune with QLoRA."
+              >
+                <Select
+                  options={baseOptions()}
+                  current={baseOptions().find((x) => x.id === store.base_model)}
+                  value={(x) => x.id}
+                  label={(x) => x.id}
+                  onSelect={(x) => x && setStore("base_model", x.id)}
+                  class="w-[320px] max-w-full"
+                  variant="secondary"
+                  size="small"
+                  triggerVariant="settings"
+                />
+              </Row>
+            </div>
+          </Show>
+
+          <Show when={activeTab() === "Data"}>
+            <div>
+              <Row title="Max repos" desc="Sources to sample from" help="Maximum repositories to pull samples from.">
+                <Num value={store.max_repos} onChange={(v) => setStore("max_repos", clampInt(v, 1, 1000))} />
+              </Row>
+              <Row title="Rounds" desc="Collection rounds" help="Number of collection rounds per repo.">
+                <Num value={store.rounds} onChange={(v) => setStore("rounds", clampInt(v, 1, 1000))} />
+              </Row>
+              <Row title="Samples per run" desc="Samples per run" help="Samples to collect per run.">
+                <Num
+                  value={store.samples_per_run}
+                  onChange={(v) => setStore("samples_per_run", clampInt(v, 1, 10000))}
+                />
+              </Row>
+            </div>
+          </Show>
+
+          <Show when={activeTab() === "Training"}>
+            <div>
+              <Row title="Train steps" desc="QLoRA steps" help="Total QLoRA training steps.">
+                <Num value={store.train_steps} onChange={(v) => setStore("train_steps", v)} />
+              </Row>
+              <Row title="Save steps" desc="Checkpoint frequency" help="How often to write checkpoints.">
+                <Num value={store.save_steps} onChange={(v) => setStore("save_steps", v)} />
+              </Row>
+              <Row title="Eval steps" desc="Evaluation frequency" help="How often to run evaluation.">
+                <Num value={store.eval_steps} onChange={(v) => setStore("eval_steps", v)} />
+              </Row>
+              <Row
+                title="Seq len"
+                desc="Max tokens"
+                help="Maximum sequence length used for training. Higher uses more VRAM."
+              >
+                <Num value={store.seq_len} onChange={(v) => setStore("seq_len", v)} />
+              </Row>
+              <Row
+                title="Batch"
+                desc="Per-device batch"
+                help="Per-device batch size for training. Higher uses more VRAM."
+              >
+                <Num value={store.batch_size} onChange={(v) => setStore("batch_size", v)} />
+              </Row>
+              <Row
+                title="Grad accum"
+                desc="Gradient accumulation"
+                help="Accumulates gradients across steps to simulate larger batches."
+              >
+                <Num value={store.grad_accum} onChange={(v) => setStore("grad_accum", v)} />
+              </Row>
+              <Row
+                title="LoRA r"
+                desc="Adapter rank"
+                help="LoRA rank (capacity). Higher can improve quality but uses more VRAM."
+              >
+                <Num value={store.lora_r} onChange={(v) => setStore("lora_r", v)} />
+              </Row>
+            </div>
+          </Show>
+
+          <Show when={activeTab() === "Budget"}>
+            <div>
+              <Row
+                title="Teacher workers"
+                desc="Parallel teacher requests"
+                help="Number of concurrent requests during dataset generation. Network-bound; try 4–12. Too high can trigger rate limits."
+              >
+                <Num value={store.teacher_workers} onChange={(v) => setStore("teacher_workers", clampInt(v, 1, 12))} />
+              </Row>
+
+              <Row
+                title="Teacher batch"
+                desc="Samples per teacher request"
+                help="Asks the teacher to return multiple samples in one JSON array. Can reduce overhead; if the teacher format gets flaky, set back to 1."
+              >
+                <Num
+                  value={store.teacher_batch_size}
+                  onChange={(v) => setStore("teacher_batch_size", clampInt(v, 1, 8))}
+                />
+              </Row>
+
+              <Row
+                title="Teacher max tokens"
+                desc="Output cap per sample"
+                help="Hard cap for the teacher output length. Lower is faster/cheaper; too low can truncate answers."
+              >
+                <Num
+                  value={store.teacher_max_tokens}
+                  onChange={(v) => setStore("teacher_max_tokens", clampInt(v, 64, 2048))}
+                />
+              </Row>
+
+              <Row title="Max requests" desc="Upper bound on teacher requests" help="Maximum teacher requests to make.">
+                <Num value={store.max_requests} onChange={(v) => setStore("max_requests", clampInt(v, 1, 1_000_000))} />
+              </Row>
+            </div>
+          </Show>
+
+          <Show when={activeTab() === "Artifacts"}>
+            <div class="p-3 text-12-regular text-text-weak">
+              Artifacts settings and locations are stored under OpenHei data/runs. (No editable fields yet)
+            </div>
+          </Show>
+
+          <Show when={activeTab() === "Monitor"}>
+            <div>
+              <div class="flex items-center justify-between gap-4 py-3 border-b border-border-weak-base last:border-none">
+                <div class="flex flex-col gap-0.5 min-w-0">
+                  <span class="text-14-medium text-text-strong">
+                    <span class="inline-flex items-center gap-2">
+                      <span>Run</span>
+                      <Help text="Starts/stops the QLoRA pump and streams logs + progress. Runs are saved under OpenHei data/runs." />
+                    </span>
+                  </span>
+                  <span class="text-12-regular text-text-weak">Start/stop pump and stream logs</span>
+                </div>
+                <div class="flex items-center gap-2">
+                  <Button size="small" variant="primary" onClick={start} disabled={store.running}>
+                    <Icon name="arrow-right" />
+                    Start
+                  </Button>
+                  <Button size="small" variant="secondary" onClick={stop} disabled={!store.running}>
+                    <Icon name="stop" />
+                    Stop
+                  </Button>
+                </div>
+              </div>
+
+              <Show when={store.run_id}>
+                <div class="py-3 text-12-regular text-text-weak">
+                  <div>run_id: {store.run_id}</div>
+                  <div>stage: {store.stage || "(unknown)"}</div>
+                  <Show when={store.progress}>
+                    {(p) => (
+                      <div>
+                        progress: {p().done}/{p().total} ({p().pct}%) | {p().rate.toFixed(2)} it/s | ETA {p().eta}s
+                      </div>
+                    )}
+                  </Show>
+                </div>
+              </Show>
+
+              <div class="pb-4">
+                <div class="bg-surface-base rounded-lg border border-border-weak-base p-3">
+                  <pre class="text-11-regular text-text-base whitespace-pre-wrap break-words max-h-[360px] overflow-auto">
+                    <For each={store.logs}>
+                      {(line) => (
+                        <span classList={{ "text-text-diff-delete-base": /\b(ERROR|FATAL)\b/.test(line) }}>
+                          {line + "\n"}
+                        </span>
+                      )}
+                    </For>
+                  </pre>
+                </div>
+              </div>
+            </div>
+          </Show>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const clampInt = (value: number, min: number, max: number) => {
+  const v = Number.isFinite(value) ? Math.trunc(value) : min
+  return Math.max(min, Math.min(max, v))
+}
+
+const Row: Component<any> = (props) => (
+  <div class="flex flex-wrap items-center justify-between gap-4 py-3 border-b border-border-weak-base last:border-none">
+    <div class="flex flex-col gap-0.5 min-w-0">
+      <span class="text-14-medium text-text-strong">
+        <span class="inline-flex items-center gap-2">
+          <span>{props.title}</span>
+          <Show when={props.help}>{(text) => <Help text={text()} />}</Show>
+        </span>
+      </span>
+      <span class="text-12-regular text-text-weak">{props.desc}</span>
+    </div>
+    <div class="flex-shrink-0 w-full sm:w-auto flex justify-end">{props.children}</div>
+  </div>
+)
+
+const Help: Component<{ text: string }> = (props) => (
+  <Popover
+    triggerAs="button"
+    triggerProps={{
+      type: "button",
+      class:
+        "text-12-regular text-text-weak hover:text-text-base transition-colors rounded px-1 py-0.5 border border-border-weak-base bg-surface-base",
+      "aria-label": "Help",
+    }}
+    trigger={<span>(!)</span>}
+    class="max-w-[280px] bg-background-base border border-border-weak-base rounded-lg shadow-[var(--shadow-lg-border-base)]"
+    placement="top"
+  >
+    <div class="text-12-regular text-text-base p-3">{props.text}</div>
+  </Popover>
+)
+
+const Num: Component<{ value: number; onChange: (v: number) => void }> = (props) => (
+  <TextField type="number" value={String(props.value)} onChange={(v) => props.onChange(Number(v))} class="w-[120px]" />
+)

--- a/packages/app/src/pages/qlora.tsx
+++ b/packages/app/src/pages/qlora.tsx
@@ -1,0 +1,5 @@
+import { SettingsQLoRA } from "@/components/settings-qlora"
+
+export default function QLoRAPage() {
+  return <SettingsQLoRA />
+}

--- a/packages/openhei/src/server/routes/qlora.ts
+++ b/packages/openhei/src/server/routes/qlora.ts
@@ -1,0 +1,957 @@
+import { Hono } from "hono"
+import { describeRoute, resolver, validator } from "hono-openapi"
+import { streamSSE } from "hono/streaming"
+import z from "zod"
+import path from "path"
+import os from "os"
+import fs from "fs/promises"
+import { Provider } from "../../provider/provider"
+import { ModelsDev } from "../../provider/models"
+import { Global } from "../../global"
+import { lazy } from "../../util/lazy"
+// ChildProcess typing from Bun is not portable here; use `any` for proc.
+
+const tools = path.join(Global.Path.data, "tools")
+const heidi = path.join(tools, "heidi-engine")
+const venv = path.join(heidi, ".venv")
+
+const runs = path.join(Global.Path.data, "runs")
+const active = path.join(Global.Path.state, "qlora.active.json")
+const installing = path.join(Global.Path.state, "qlora.install.json")
+const configPath = path.join(Global.Path.state, "qlora.config.json")
+
+const getpy = async () => {
+  const a = path.join(venv, "bin", "python")
+  const b = path.join(venv, "Scripts", "python.exe")
+  const aok = await fs
+    .stat(a)
+    .then(() => a)
+    .catch(() => undefined)
+  if (aok) return aok
+  const bok = await fs
+    .stat(b)
+    .then(() => b)
+    .catch(() => undefined)
+  return bok
+}
+
+const exists = (p: string) =>
+  fs
+    .stat(p)
+    .then(() => true)
+    .catch(() => false)
+
+const run = async (cmd: string[], opts?: { cwd?: string; env?: Record<string, string> }) => {
+  try {
+    const proc = Bun.spawn(cmd, {
+      cwd: opts?.cwd,
+      env: { ...process.env, ...(opts?.env ?? {}) },
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const [out, err] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()])
+    const code = await proc.exited
+    return { code, out, err }
+  } catch (e) {
+    const err = e instanceof Error ? e.stack || e.message : String(e)
+    return { code: 127, out: "", err }
+  }
+}
+
+const spawnLogged = (cmd: string[], logPath: string, opts?: { env?: Record<string, string> }) => {
+  const proc = Bun.spawn(cmd, {
+    env: { ...process.env, ...(opts?.env ?? {}) },
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+
+  const sink = Bun.file(logPath).writer()
+  const pump = async (stream: ReadableStream<Uint8Array> | null) => {
+    if (!stream) return
+    const reader = stream.getReader()
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) return
+      if (value) sink.write(value)
+    }
+  }
+
+  void Promise.all([pump(proc.stdout), pump(proc.stderr)]).finally(async () => {
+    await sink.end()
+  })
+
+  return proc
+}
+
+const findpy = async () => {
+  const v = await getpy()
+  if (v) {
+    const ok = await run([v, "-c", "import heidi_engine"]).then((x) => x.code === 0)
+    if (ok) return v
+  }
+  const ok = await run(["python3", "-c", "import heidi_engine"]).then((x) => x.code === 0)
+  return ok ? "python3" : undefined
+}
+
+const pidok = (pid: number) => {
+  if (!pid) return false
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const findInstallPidByPs = async () => {
+  if (process.platform === "win32") return
+  const out = await run(["ps", "-eo", "pid,args"]).then((x) => (x.code === 0 ? x.out : ""))
+  if (!out) return
+  const lines = out.split(/\r?\n/)
+  for (const line of lines) {
+    if (!line.includes("pip")) continue
+    if (!line.includes("heidi-engine")) continue
+    if (!line.includes(heidi)) continue
+    const m = line.trim().match(/^([0-9]+)\s+/)
+    if (m) return Number(m[1])
+  }
+}
+
+const sleep = (ms: number) => Bun.sleep(ms)
+
+const killpid = async (pid: number, signal: "SIGTERM" | "SIGKILL") => {
+  if (!pid) return
+  if (process.platform === "win32") {
+    if (signal === "SIGKILL") {
+      const p = Bun.spawn(["taskkill", "/PID", String(pid), "/T", "/F"], { stdout: "ignore", stderr: "ignore" })
+      await p.exited
+      return
+    }
+    try {
+      process.kill(pid, "SIGTERM")
+    } catch {
+      // ignore
+    }
+    return
+  }
+
+  const send = (target: number) => {
+    try {
+      process.kill(target, signal)
+    } catch {
+      // ignore
+    }
+  }
+  send(pid)
+  // Best-effort: also try process group if detached.
+  send(-pid)
+}
+
+const waitdead = async (pid: number, timeout_ms: number) => {
+  const start = Date.now()
+  while (pidok(pid) && Date.now() - start < timeout_ms) await sleep(125)
+  return !pidok(pid)
+}
+
+const redact = (line: string) => {
+  return line
+    .replace(/\bsk-[A-Za-z0-9]{16,}\b/g, "sk-***REDACTED***")
+    .replace(/\bhf_[A-Za-z0-9]{16,}\b/g, "hf_***REDACTED***")
+    .replace(
+      /\b(OPENAI_API_KEY|OPENAI_KEY|HF_TOKEN|HUGGINGFACE_HUB_TOKEN|ANTHROPIC_API_KEY|GEMINI_API_KEY)=\S+/g,
+      "$1=***REDACTED***",
+    )
+    .replace(/\b(Authorization:\s*Bearer\s+)\S+/gi, "$1***REDACTED***")
+}
+
+const readactive = async () => {
+  const text = await fs.readFile(active, "utf-8").catch(() => "")
+  if (!text) return
+  const data = z
+    .object({ run_id: z.string(), pid: z.number().int(), started_at: z.string() })
+    .safeParse(JSON.parse(text))
+  if (!data.success) return
+  return data.data
+}
+
+const readinstall = async () => {
+  const text = await fs.readFile(installing, "utf-8").catch(() => "")
+  if (!text) return
+  const data = z.object({ pid: z.number().int(), started_at: z.string(), log: z.string() }).safeParse(JSON.parse(text))
+  if (!data.success) return
+  return data.data
+}
+
+const writeinstall = async (data: { pid: number; started_at: string; log: string } | undefined) => {
+  await fs.mkdir(path.dirname(installing), { recursive: true })
+  if (!data) {
+    await fs.rm(installing, { force: true })
+    return
+  }
+  await fs.writeFile(installing, JSON.stringify(data, null, 2) + "\n")
+}
+
+const writeactive = async (data: { run_id: string; pid: number; started_at: string } | undefined) => {
+  await fs.mkdir(path.dirname(active), { recursive: true })
+  if (!data) {
+    await fs.rm(active, { force: true })
+    return
+  }
+  await fs.writeFile(active, JSON.stringify(data, null, 2) + "\n")
+}
+
+const attachok = async (url: string) => {
+  const doc = url.replace(/\/+$/, "") + "/doc"
+  const res = await fetch(doc, { signal: AbortSignal.timeout(2500) }).catch(() => undefined)
+  return !!res && res.ok
+}
+
+const basemodels = async () => {
+  const home = os.homedir()
+  const envHome = process.env.HOME
+  const realHome = envHome && envHome.includes("/snap/") ? envHome.split("/snap/")[0] : envHome
+
+  const roots = new Set<string>()
+  const add = (p?: string) => {
+    if (!p) return
+    const v = p.trim()
+    if (!v) return
+    roots.add(v)
+  }
+
+  add(process.env.HUGGINGFACE_HUB_CACHE)
+  add(process.env.HF_HOME)
+  add(process.env.TRANSFORMERS_CACHE)
+  add(process.env.XDG_CACHE_HOME && path.join(process.env.XDG_CACHE_HOME, "huggingface"))
+  add(path.join(home, ".cache", "huggingface"))
+  add(envHome && path.join(envHome, ".cache", "huggingface"))
+  add(realHome && path.join(realHome, ".cache", "huggingface"))
+  add(path.join(home, "huggingface"))
+  add(realHome && path.join(realHome, "huggingface"))
+
+  // Snap installs often place cache under ~/snap/<app>/<rev>/.cache
+  const snap = path.join(realHome ?? home, "snap")
+  const snapApps = await fs.readdir(snap).catch(() => [])
+  for (const app of snapApps.slice(0, 25)) {
+    const base = path.join(snap, app)
+    const revs = await fs.readdir(base).catch(() => [])
+    for (const rev of revs.slice(0, 10)) {
+      roots.add(path.join(base, rev, ".cache", "huggingface"))
+    }
+  }
+
+  const models: string[] = []
+  for (const root of roots) {
+    const hub = path.join(root, "hub")
+    const list = await fs.readdir(hub).catch(() => [])
+    for (const x of list) {
+      if (!x.startsWith("models--")) continue
+      const id = x
+        .replace(/^models--/, "")
+        .split("--")
+        .slice(0, 2)
+        .join("/")
+      if (id.includes("/")) models.push(id)
+    }
+  }
+  return [...new Set(models)].sort((a, b) => a.localeCompare(b))
+}
+
+const teacher = z
+  .object({
+    teacher_backend: z.enum(["legacy", "openhei"]).default("openhei"),
+    teacher_model: z.string().min(1).max(200),
+    teacher_workers: z.number().int().min(1).max(12).default(1),
+    teacher_batch_size: z.number().int().min(1).max(8).default(1),
+    teacher_max_tokens: z.number().int().min(64).max(2048).default(256),
+    openhei_attach: z
+      .string()
+      .url()
+      .max(200)
+      .refine((u) => u.startsWith("http://") || u.startsWith("https://"), { message: "must be http(s)" })
+      .default("http://127.0.0.1:4100"),
+    openhei_agent: z
+      .string()
+      .max(64)
+      .regex(/^[a-zA-Z0-9._-]*$/)
+      .optional()
+      .default(""),
+    openhei_start: z.boolean().optional().default(false),
+    openhei_attach_strict: z.boolean().optional().default(false),
+  })
+  .strict()
+
+const cfg = z
+  .object({
+    run_id: z
+      .string()
+      .min(1)
+      .max(80)
+      .regex(/^[a-zA-Z0-9._-]+$/)
+      .optional(),
+    stack: z
+      .string()
+      .max(40)
+      .regex(/^[a-zA-Z0-9_-]+$/)
+      .default("python"),
+    max_repos: z.number().int().min(1).max(500).default(50),
+    rounds: z.number().int().min(1).max(50).default(2),
+    samples_per_run: z.number().int().min(1).max(5000).default(100),
+    max_requests: z.number().int().min(1).max(1_000_000).default(10_000),
+    base_model: z.string().min(1).max(200),
+    train_steps: z.number().int().min(1).max(1_000_000).default(1200),
+    save_steps: z.number().int().min(1).max(1_000_000).default(100),
+    eval_steps: z.number().int().min(1).max(1_000_000).default(200),
+    seq_len: z.number().int().min(128).max(8192).default(1024),
+    batch_size: z.number().int().min(1).max(16).default(1),
+    grad_accum: z.number().int().min(1).max(128).default(8),
+    lora_r: z.number().int().min(4).max(256).default(32),
+    val_ratio: z.number().min(0).max(0.5).default(0.05),
+    teacher: teacher,
+  })
+  .strict()
+
+type Run = {
+  run_id: string
+  pid: number
+  started_at: string
+  dir: string
+  log: string
+  proc: any
+}
+
+const state = { run: undefined as Run | undefined }
+
+export const QLoRARoutes = lazy(() =>
+  new Hono()
+    .get(
+      "/config",
+      describeRoute({
+        summary: "Get QLoRA config",
+        operationId: "qlora.get_config",
+        responses: {
+          200: {
+            description: "Config",
+            content: {
+              "application/json": {
+                schema: resolver(cfg),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        const txt = await fs.readFile(configPath, "utf-8").catch(() => "")
+        if (!txt)
+          return c.json(
+            cfg.parse({
+              stack: "python",
+              max_repos: 50,
+              rounds: 2,
+              samples_per_run: 100,
+              max_requests: 10000,
+              base_model: "mistralai/Mistral-7B-Instruct-v0.2",
+              train_steps: 1200,
+              save_steps: 100,
+              eval_steps: 200,
+              seq_len: 1024,
+              batch_size: 1,
+              grad_accum: 8,
+              lora_r: 32,
+              val_ratio: 0.05,
+              teacher: {
+                teacher_backend: "openhei",
+                teacher_model: "openai/gpt-5.2",
+                teacher_workers: 1,
+                teacher_batch_size: 1,
+                teacher_max_tokens: 256,
+                openhei_attach: "http://127.0.0.1:4100",
+                openhei_agent: "",
+                openhei_start: false,
+                openhei_attach_strict: false,
+              },
+            }),
+          )
+
+        try {
+          const parsed = JSON.parse(txt)
+          const ok = cfg.parse(parsed)
+          return c.json(ok)
+        } catch (e) {
+          // If config is corrupt, return default cfg
+          const def = cfg.parse({
+            stack: "python",
+            max_repos: 50,
+            rounds: 2,
+            samples_per_run: 100,
+            max_requests: 10000,
+            base_model: "mistralai/Mistral-7B-Instruct-v0.2",
+            train_steps: 1200,
+            save_steps: 100,
+            eval_steps: 200,
+            seq_len: 1024,
+            batch_size: 1,
+            grad_accum: 8,
+            lora_r: 32,
+            val_ratio: 0.05,
+            teacher: {
+              teacher_backend: "openhei",
+              teacher_model: "openai/gpt-5.2",
+              teacher_workers: 1,
+              teacher_batch_size: 1,
+              teacher_max_tokens: 256,
+              openhei_attach: "http://127.0.0.1:4100",
+              openhei_agent: "",
+              openhei_start: false,
+              openhei_attach_strict: false,
+            },
+          })
+          return c.json(def)
+        }
+      },
+    )
+    .put(
+      "/config",
+      describeRoute({
+        summary: "Save QLoRA config",
+        operationId: "qlora.put_config",
+        responses: {
+          200: {
+            description: "Saved",
+            content: {
+              "application/json": {
+                schema: resolver(cfg),
+              },
+            },
+          },
+        },
+      }),
+      validator("json", cfg),
+      async (c) => {
+        const body = c.req.valid("json")
+        await fs.mkdir(path.dirname(configPath), { recursive: true })
+        await fs.writeFile(configPath, JSON.stringify(body, null, 2) + "\n")
+        return c.json(body)
+      },
+    )
+    .get(
+      "/doctor",
+      describeRoute({
+        summary: "QLoRA doctor",
+        operationId: "qlora.doctor",
+        responses: {
+          200: {
+            description: "Doctor report",
+            content: {
+              "application/json": {
+                schema: resolver(
+                  z
+                    .object({
+                      installed: z.boolean(),
+                      tool_dir: z.string(),
+                      python: z.string().optional(),
+                      version: z.string().optional(),
+                      gpu: z.string().optional(),
+                      disk: z.object({ path: z.string(), free_bytes: z.number().int().nonnegative() }).optional(),
+                      install: z.object({ pid: z.number().int(), started_at: z.string(), log: z.string() }).optional(),
+                      active: z
+                        .object({ run_id: z.string(), pid: z.number().int(), started_at: z.string() })
+                        .optional(),
+                    })
+                    .strict(),
+                ),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        const py = await findpy()
+        const installed = !!py
+
+        const a = await readactive()
+        const active_ = a && pidok(a.pid) ? a : undefined
+        if (a && !active_) await writeactive(undefined)
+
+        const i = await readinstall()
+        const install_ = i && pidok(i.pid) ? i : undefined
+        if (i && !install_) await writeinstall(undefined)
+
+        const version =
+          py &&
+          (await run([py, "-c", "import importlib.metadata as m; print(m.version('heidi-engine'))"]).then((x) =>
+            x.code === 0 ? x.out.trim() : undefined,
+          ))
+
+        const gpu = await run(["nvidia-smi", "-L"]).then((x) => (x.code === 0 ? x.out.trim() : undefined))
+
+        const disk = await run(["df", "-k", Global.Path.data]).then((x) => {
+          if (x.code !== 0) return
+          const line = x.out
+            .split(/\r?\n/)
+            .filter((y) => y)
+            .slice(-1)[0]
+          const parts = line?.trim().split(/\s+/)
+          const free = parts?.[3]
+          const free_bytes = free ? Number(free) * 1024 : 0
+          if (!Number.isFinite(free_bytes)) return
+          return { path: Global.Path.data, free_bytes }
+        })
+
+        return c.json({
+          installed,
+          tool_dir: heidi,
+          python: py ?? undefined,
+          version: version || undefined,
+          gpu,
+          disk,
+          install: install_ || undefined,
+          active: active_ || undefined,
+        })
+      },
+    )
+    .post(
+      "/install",
+      describeRoute({
+        summary: "Install heidi-engine pump",
+        operationId: "qlora.install",
+        responses: {
+          200: {
+            description: "Install result",
+            content: {
+              "application/json": {
+                schema: resolver(z.object({ ok: z.boolean(), message: z.string() }).strict()),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        await fs.mkdir(tools, { recursive: true })
+        const py = await run(["python3", "-V"]).then((x) => (x.code === 0 ? "python3" : undefined))
+        if (!py) return c.json({ ok: false, message: "python3 not found in PATH" })
+
+        await fs.mkdir(heidi, { recursive: true })
+
+        const src = "https://github.com/heidi-dang/heidi-engine/archive/refs/heads/main.zip"
+        const local = "/home/heidi/work/heidi-engine"
+        const localOk = await exists(path.join(local, "pyproject.toml"))
+        const spec = localOk ? `${local}[ml]` : `heidi-engine[ml] @ ${src}`
+
+        let basePip = await run([py, "-m", "pip", "--version"])
+        if (basePip.code !== 0) {
+          const ep = await run([py, "-m", "ensurepip", "--upgrade"])
+          if (ep.code === 0) basePip = await run([py, "-m", "pip", "--version"])
+        }
+        if (basePip.code !== 0) {
+          const url = "https://bootstrap.pypa.io/get-pip.py"
+          const text = await fetch(url, { signal: AbortSignal.timeout(10_000) })
+            .then((r) => (r.ok ? r.text() : ""))
+            .catch(() => "")
+          if (text) {
+            const gp = path.join(heidi, "get-pip.py")
+            await fs.writeFile(gp, text)
+            await run([py, gp, "--user"])
+            basePip = await run([py, "-m", "pip", "--version"])
+          }
+        }
+        if (basePip.code !== 0) {
+          return c.json({
+            ok: false,
+            message: basePip.err.trim() || basePip.out.trim() || "python3 pip not found (install python3-pip)",
+          })
+        }
+
+        const cur = await readinstall()
+        if (cur && pidok(cur.pid)) return c.json({ ok: true, message: "install already running" })
+        if (cur && !pidok(cur.pid)) await writeinstall(undefined)
+
+        const existing = await findInstallPidByPs()
+        if (existing && pidok(existing)) {
+          await writeinstall({ pid: existing, started_at: new Date().toISOString(), log: "unknown" })
+          return c.json({ ok: true, message: "install already running" })
+        }
+
+        // Prefer an isolated venv when possible.
+        if (!(await exists(venv))) {
+          const v = await run([py, "-m", "venv", venv])
+          if (v.code !== 0) {
+            // Best-effort: fall back to virtualenv if available.
+            await run([py, "-m", "pip", "install", "--user", "-U", "virtualenv"])
+            await run([py, "-m", "virtualenv", venv])
+          }
+        }
+
+        const ensureVenvPip = async () => {
+          const p = await getpy()
+          if (!p) return
+          const pip = await run([p, "-m", "pip", "--version"])
+          if (pip.code === 0) return p
+          await run([p, "-m", "ensurepip", "--upgrade"])
+          const pip2 = await run([p, "-m", "pip", "--version"])
+          if (pip2.code === 0) return p
+
+          await run([py, "-m", "pip", "install", "--user", "-U", "virtualenv"])
+          await fs.rm(venv, { recursive: true, force: true })
+          const vv = await run([py, "-m", "virtualenv", venv])
+          if (vv.code !== 0) return
+          const p2 = await getpy()
+          if (!p2) return
+          const pip3 = await run([p2, "-m", "pip", "--version"])
+          return pip3.code === 0 ? p2 : undefined
+        }
+
+        const vpy = await ensureVenvPip()
+        const pipPy = vpy ?? py
+        const pipArgs = vpy ? [] : ["--user"]
+
+        await run([pipPy, "-m", "pip", "install", ...pipArgs, "-U", "pip"])
+        const deps = await run([pipPy, "-m", "pip", "install", ...pipArgs, "-U", "setuptools", "wheel"])
+        if (deps.code !== 0) {
+          return c.json({ ok: false, message: deps.err.trim() || deps.out.trim() || "python deps install failed" })
+        }
+
+        const log = path.join(heidi, `install-${dt()}.log`)
+        const base = [pipPy, "-m", "pip", "install", ...pipArgs, "-U"]
+        const cmd = localOk ? [...base, "-e", spec] : [...base, spec]
+        const proc = spawnLogged(cmd, log)
+
+        const started_at = new Date().toISOString()
+        await writeinstall({ pid: proc.pid, started_at, log })
+        void proc.exited.then(async () => {
+          const cur = await readinstall()
+          if (cur && cur.pid === proc.pid) await writeinstall(undefined)
+        })
+
+        return c.json({ ok: true, message: "install started" })
+      },
+    )
+    .get(
+      "/teacher-models",
+      describeRoute({
+        summary: "Teacher models",
+        operationId: "qlora.teacher_models",
+        responses: {
+          200: {
+            description: "Teacher models",
+            content: {
+              "application/json": {
+                schema: resolver(z.object({ models: z.array(z.string()) }).strict()),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        const list = await Provider.list()
+          .then((providers) =>
+            Object.entries(providers).flatMap(([pid, p]) => Object.keys(p.models).map((mid) => `${pid}/${mid}`)),
+          )
+          .catch(async () => {
+            const all = await ModelsDev.get()
+            return Object.entries(all).flatMap(([pid, p]) => Object.keys(p.models).map((mid) => `${pid}/${mid}`))
+          })
+
+        const models = [...new Set(list)].sort((a, b) => a.localeCompare(b))
+        return c.json({ models })
+      },
+    )
+    .get(
+      "/base-models",
+      describeRoute({
+        summary: "Base models",
+        operationId: "qlora.base_models",
+        responses: {
+          200: {
+            description: "Base models",
+            content: {
+              "application/json": {
+                schema: resolver(z.object({ models: z.array(z.string()) }).strict()),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => c.json({ models: await basemodels() }),
+    )
+    .post(
+      "/start",
+      describeRoute({
+        summary: "Start pump",
+        operationId: "qlora.start",
+        responses: {
+          200: {
+            description: "Started",
+            content: {
+              "application/json": {
+                schema: resolver(
+                  z.object({ ok: z.boolean(), run_id: z.string().optional(), message: z.string() }).strict(),
+                ),
+              },
+            },
+          },
+        },
+      }),
+      validator("json", cfg),
+      async (c) => {
+        const py = await findpy()
+        if (!py) return c.json({ ok: false, message: "heidi-engine not installed (run Install first)" })
+
+        const a = await readactive()
+        if (a && pidok(a.pid)) return c.json({ ok: false, message: `already running: ${a.run_id}` })
+        if (state.run && pidok(state.run.pid))
+          return c.json({ ok: false, message: `already running: ${state.run.run_id}` })
+
+        const input = c.req.valid("json")
+        const run_id = input.run_id || dt()
+        const dir = path.join(runs, run_id)
+        const log = path.join(dir, "pump.log")
+        await fs.mkdir(dir, { recursive: true })
+
+        const attach = input.teacher.openhei_attach || "http://127.0.0.1:4100"
+        if (!input.teacher.openhei_start) {
+          const ok = await attachok(attach)
+          if (!ok) return c.json({ ok: false, message: `attach not reachable: ${attach}/doc` })
+        }
+
+        const args = [
+          py,
+          "-m",
+          "heidi_engine.pump",
+          "--runs-dir",
+          runs,
+          "--run-id",
+          run_id,
+          "--stack",
+          input.stack,
+          "--max-repos",
+          String(input.max_repos),
+          "--rounds",
+          String(input.rounds),
+          "--samples-per-run",
+          String(input.samples_per_run),
+          "--max-requests",
+          String(input.max_requests),
+          "--teacher-backend",
+          input.teacher.teacher_backend,
+          "--teacher-model",
+          input.teacher.teacher_model,
+          "--openhei-attach",
+          attach,
+          "--openhei-agent",
+          input.teacher.openhei_agent || "",
+          "--base-model",
+          input.base_model,
+          "--train-steps",
+          String(input.train_steps),
+          "--save-steps",
+          String(input.save_steps),
+          "--eval-steps",
+          String(input.eval_steps),
+          "--val-ratio",
+          String(input.val_ratio),
+        ]
+
+        if (input.teacher.openhei_start) {
+          args.push("--openhei-start")
+          args.push("--openhei-host", "127.0.0.1")
+          args.push("--openhei-port", "4100")
+        }
+        if (input.teacher.openhei_attach_strict) args.push("--openhei-attach-strict")
+
+        const env = {
+          TEACHER_WORKERS: String(input.teacher.teacher_workers),
+          TEACHER_BATCH_SIZE: String(input.teacher.teacher_batch_size),
+          TEACHER_MAX_TOKENS: String(input.teacher.teacher_max_tokens),
+          SEQ_LEN: String(input.seq_len),
+          BATCH_SIZE: String(input.batch_size),
+          GRAD_ACCUM: String(input.grad_accum),
+          LORA_R: String(input.lora_r),
+        }
+
+        // If a local checkout exists, tell pump where scripts live.
+        const local = "/home/heidi/work/heidi-engine"
+        if (await exists(path.join(local, "scripts"))) env["HEIDI_ENGINE_PROJECT_ROOT"] = local
+
+        // Ensure heidi-engine can find the OpenHei CLI even when it's not in PATH.
+        const cli = "/home/heidi/src/openhei/packages/openhei/src/index.ts"
+        if (await exists(cli)) env["OPENHEI_CLI"] = `/snap/bin/bun run --conditions=browser ${cli}`
+
+        const proc = spawnLogged(args, log, { env })
+
+        const started_at = new Date().toISOString()
+        state.run = { run_id, pid: proc.pid, started_at, dir, log, proc }
+        await writeactive({ run_id, pid: proc.pid, started_at })
+
+        void proc.exited.then(async () => {
+          if (state.run?.run_id === run_id) state.run = undefined
+          const cur = await readactive()
+          if (cur?.run_id === run_id) await writeactive(undefined)
+        })
+
+        return c.json({ ok: true, run_id, message: "started" })
+      },
+    )
+    .post(
+      "/stop",
+      describeRoute({
+        summary: "Stop pump",
+        operationId: "qlora.stop",
+        responses: {
+          200: {
+            description: "Stopped",
+            content: {
+              "application/json": {
+                schema: resolver(z.object({ ok: z.boolean(), message: z.string() }).strict()),
+              },
+            },
+          },
+        },
+      }),
+      validator("json", z.object({ run_id: z.string().optional() }).strict()),
+      async (c) => {
+        const run_id = c.req.valid("json").run_id
+        const a = await readactive()
+        const sr = state.run && pidok(state.run.pid) ? state.run : undefined
+        const ar = a && pidok(a.pid) ? a : undefined
+
+        const target = run_id ? (sr?.run_id === run_id ? sr : ar?.run_id === run_id ? ar : undefined) : (sr ?? ar)
+        if (!target) {
+          await writeactive(undefined)
+          state.run = undefined
+          return c.json({ ok: true, message: "not running" })
+        }
+        if (run_id && target.run_id !== run_id) return c.json({ ok: false, message: "run_id mismatch" })
+
+        await killpid(target.pid, "SIGTERM")
+        await waitdead(target.pid, 2000)
+        if (pidok(target.pid)) {
+          await killpid(target.pid, "SIGKILL")
+          await waitdead(target.pid, 1500)
+        }
+
+        await writeactive(undefined)
+        state.run = undefined
+        return c.json({ ok: true, message: "stopped" })
+      },
+    )
+    .get(
+      "/status",
+      describeRoute({
+        summary: "Pump status",
+        operationId: "qlora.status",
+        responses: {
+          200: {
+            description: "Status",
+            content: {
+              "application/json": {
+                schema: resolver(
+                  z
+                    .object({
+                      ok: z.boolean(),
+                      run_id: z.string().optional(),
+                      running: z.boolean(),
+                      stage: z.string().optional(),
+                      status: z.record(z.string(), z.any()).optional(),
+                      ready: z.record(z.string(), z.any()).optional(),
+                    })
+                    .strict(),
+                ),
+              },
+            },
+          },
+        },
+      }),
+      validator("query", z.object({ run_id: z.string().optional() }).strict()),
+      async (c) => {
+        const run_id = c.req.valid("query").run_id
+        const a = await readactive()
+        const rid = run_id || a?.run_id
+        if (!rid) return c.json({ ok: true, running: false })
+
+        const dir = path.join(runs, rid)
+        const status = await fs
+          .readFile(path.join(dir, "status.json"), "utf-8")
+          .then((x) => JSON.parse(x) as Record<string, unknown>)
+          .catch(() => undefined)
+        const ready = await fs
+          .readFile(path.join(dir, "READY.json"), "utf-8")
+          .then((x) => JSON.parse(x) as Record<string, unknown>)
+          .catch(() => undefined)
+        const running = a ? pidok(a.pid) : false
+        const stage = typeof status?.stage === "string" ? (status.stage as string) : undefined
+        return c.json({ ok: true, run_id: rid, running, stage, status, ready })
+      },
+    )
+    .get(
+      "/logs",
+      describeRoute({
+        summary: "Stream logs",
+        operationId: "qlora.logs",
+        responses: {
+          200: {
+            description: "Log stream",
+            content: {
+              "text/event-stream": {
+                schema: resolver(z.any()),
+              },
+            },
+          },
+        },
+      }),
+      validator("query", z.object({ run_id: z.string() }).strict()),
+      async (c) => {
+        const run_id = c.req.valid("query").run_id
+        const file = path.join(runs, run_id, "pump.log")
+        c.header("X-Accel-Buffering", "no")
+        c.header("X-Content-Type-Options", "nosniff")
+
+        let pos = 0
+        const send = async (stream: { writeSSE: (x: { data: string }) => Promise<void> }) => {
+          const stat = await fs.stat(file).catch(() => undefined)
+          if (!stat) return
+          if (stat.size <= pos) return
+          const fd = await fs.open(file, "r")
+          const buf = Buffer.alloc(stat.size - pos)
+          await fd.read(buf, 0, buf.length, pos)
+          await fd.close()
+          pos = stat.size
+
+          const text = buf.toString("utf-8")
+          const lines = text.split(/\r?\n/).filter((x) => x)
+          for (const line of lines) {
+            const m = line.match(/\[INFO\] Generated (\d+)\/(\d+) \((\d+)%\) \| ([0-9.]+) it\/s \| ETA (\d+)s/)
+            if (m) {
+              await stream.writeSSE({
+                data: JSON.stringify({
+                  type: "progress",
+                  done: Number(m[1]),
+                  total: Number(m[2]),
+                  pct: Number(m[3]),
+                  rate: Number(m[4]),
+                  eta: Number(m[5]),
+                }),
+              })
+              continue
+            }
+            await stream.writeSSE({ data: JSON.stringify({ type: "log", line: redact(line) }) })
+          }
+        }
+
+        return streamSSE(c, async (stream) => {
+          await stream.writeSSE({ data: JSON.stringify({ type: "connected" }) })
+          const t = setInterval(() => {
+            void send(stream)
+          }, 250)
+          await new Promise<void>((resolve) => {
+            stream.onAbort(() => {
+              clearInterval(t)
+              resolve()
+            })
+          })
+        })
+      },
+    ),
+)
+
+const dt = () => new Date().toISOString().replaceAll(":", "").replaceAll(".", "-")


### PR DESCRIPTION
Adds a tabbed QLoRA control board with client/server config persistence, Save button, per-tab dirty badges, Monitor tab with Start/Stop/logs, and hydation from localStorage + server.\n\nFiles:\n- packages/app/src/components/settings-qlora.tsx\n- packages/app/src/pages/qlora.tsx\n- packages/openhei/src/server/routes/qlora.ts\n\nNotes:\n- Start uses last saved config; warns if unsaved changes exist.\n- Local TS diagnostics were addressed in the UI file; recommend CI run to verify types.\n