### PR TITLE
Remove Bun cache workaround for proxied connections

### DIFF
--- a/packages/openhei/src/bun/index.ts
+++ b/packages/openhei/src/bun/index.ts
@@ -7,7 +7,6 @@ import { NamedError } from "@openhei-ai/util/error"
 import { readableStreamToText } from "bun"
 import { Lock } from "../util/lock"
 import { PackageRegistry } from "./registry"
-import { proxied } from "@/util/proxied"
 
 export namespace BunProc {
   const log = Log.create({ service: "bun" })
@@ -92,8 +91,6 @@ export namespace BunProc {
       "add",
       "--force",
       "--exact",
-      // TODO: get rid of this case (see: https://github.com/oven-sh/bun/issues/19936)
-      ...(proxied() ? ["--no-cache"] : []),
       "--cwd",
       Global.Path.cache,
       pkg + "@" + version,

--- a/packages/openhei/src/config/config.ts
+++ b/packages/openhei/src/config/config.ts
@@ -30,7 +30,6 @@ import { GlobalBus } from "@/bus/global"
 import { Event } from "../server/event"
 import { Glob } from "../util/glob"
 import { PackageRegistry } from "@/bun/registry"
-import { proxied } from "@/util/proxied"
 import { iife } from "@/util/iife"
 import { Control } from "@/control"
 
@@ -288,8 +287,6 @@ export namespace Config {
     await BunProc.run(
       [
         "install",
-        // TODO: get rid of this case (see: https://github.com/oven-sh/bun/issues/19936)
-        ...(proxied() ? ["--no-cache"] : []),
       ],
       { cwd: dir },
     ).catch((err) => {

--- a/packages/openhei/src/util/proxied.ts
+++ b/packages/openhei/src/util/proxied.ts
@@ -1,3 +1,0 @@
-export function proxied() {
-  return !!(process.env.HTTP_PROXY || process.env.HTTPS_PROXY || process.env.http_proxy || process.env.https_proxy)
-}


### PR DESCRIPTION
Removes the workaround for Bun issue #19936 (disabling cache for proxied connections) from `packages/openhei/src/config/config.ts` and `packages/openhei/src/bun/index.ts`, and deletes the unused `packages/openhei/src/util/proxied.ts` utility file.

---
*PR created automatically by Jules for task [17901904928252262133](https://jules.google.com/task/17901904928252262133) started by @heidi-dang*