### PR TITLE
Fix HTML tree-sitter injections

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "openhei",
@@ -537,6 +536,7 @@
   "patchedDependencies": {
     "@openrouter/ai-sdk-provider@1.5.4": "patches/@openrouter%2Fai-sdk-provider@1.5.4.patch",
     "@standard-community/standard-openapi@0.2.9": "patches/@standard-community%2Fstandard-openapi@0.2.9.patch",
+    "@opentui/core@0.1.79": "patches/@opentui%2Fcore@0.1.79.patch",
   },
   "overrides": {
     "@types/bun": "catalog:",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
   },
   "patchedDependencies": {
     "@standard-community/standard-openapi@0.2.9": "patches/@standard-community%2Fstandard-openapi@0.2.9.patch",
-    "@openrouter/ai-sdk-provider@1.5.4": "patches/@openrouter%2Fai-sdk-provider@1.5.4.patch"
+    "@openrouter/ai-sdk-provider@1.5.4": "patches/@openrouter%2Fai-sdk-provider@1.5.4.patch",
+    "@opentui/core@0.1.79": "patches/@opentui%2Fcore@0.1.79.patch"
   }
 }

--- a/packages/openhei/parsers-config.ts
+++ b/packages/openhei/parsers-config.ts
@@ -142,10 +142,9 @@ export default {
           // "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/refs/heads/master/queries/html/highlights.scm",
           "https://github.com/tree-sitter/tree-sitter-html/raw/refs/heads/master/queries/highlights.scm",
         ],
-        // TODO: Injections not working for some reason
-        // injections: [
-        //   "https://github.com/tree-sitter/tree-sitter-html/raw/refs/heads/master/queries/injections.scm",
-        // ],
+        injections: [
+          "https://github.com/tree-sitter/tree-sitter-html/raw/refs/heads/master/queries/injections.scm",
+        ],
       },
       // injectionMapping: {
       //   nodeTypes: {

--- a/patches/@opentui%2Fcore@0.1.79.patch
+++ b/patches/@opentui%2Fcore@0.1.79.patch
@@ -1,0 +1,73 @@
+diff --git a/parser.worker.js b/parser.worker.js
+index f4ca47e196a8bfdc65cfec9329853bbfc8a9e7bd..7cf384969e07bf095cede35d7f99d15f9f7fd177 100644
+--- a/parser.worker.js
++++ b/parser.worker.js
+@@ -380,38 +380,43 @@ class ParserWorker {
+       return { captures: injectionMatches, injectionRanges };
+     }
+     const content = parserState.content;
+-    const injectionCaptures = parserState.queries.injections.captures(parserState.tree.rootNode);
++    const matches = parserState.queries.injections.matches(parserState.tree.rootNode);
+     const languageGroups = new Map;
+     const injectionMapping = parserState.injectionMapping;
+-    for (const capture of injectionCaptures) {
+-      const captureName = capture.name;
+-      if (captureName === "injection.content" || captureName.includes("injection")) {
+-        const nodeType = capture.node.type;
+-        let targetLanguage;
+-        if (injectionMapping?.nodeTypes && injectionMapping.nodeTypes[nodeType]) {
+-          targetLanguage = injectionMapping.nodeTypes[nodeType];
+-        } else if (nodeType === "code_fence_content") {
+-          const parent = capture.node.parent;
+-          if (parent) {
+-            const infoString = parent.children.find((child) => child.type === "info_string");
+-            if (infoString) {
+-              const languageNode = infoString.children.find((child) => child.type === "language");
+-              if (languageNode) {
+-                const languageName = this.getNodeText(languageNode, content);
+-                if (injectionMapping?.infoStringMap && injectionMapping.infoStringMap[languageName]) {
+-                  targetLanguage = injectionMapping.infoStringMap[languageName];
+-                } else {
+-                  targetLanguage = languageName;
++    for (const match of matches) {
++      for (const capture of match.captures) {
++        const captureName = capture.name;
++        if (captureName === "injection.content" || captureName.includes("injection")) {
++          const nodeType = capture.node.type;
++          let targetLanguage;
++          if (match.setProperties && match.setProperties["injection.language"]) {
++            targetLanguage = match.setProperties["injection.language"];
++          }
++          if (!targetLanguage && injectionMapping?.nodeTypes && injectionMapping.nodeTypes[nodeType]) {
++            targetLanguage = injectionMapping.nodeTypes[nodeType];
++          } else if (!targetLanguage && nodeType === "code_fence_content") {
++            const parent = capture.node.parent;
++            if (parent) {
++              const infoString = parent.children.find((child) => child.type === "info_string");
++              if (infoString) {
++                const languageNode = infoString.children.find((child) => child.type === "language");
++                if (languageNode) {
++                  const languageName = this.getNodeText(languageNode, content);
++                  if (injectionMapping?.infoStringMap && injectionMapping.infoStringMap[languageName]) {
++                    targetLanguage = injectionMapping.infoStringMap[languageName];
++                  } else {
++                    targetLanguage = languageName;
++                  }
+                 }
+               }
+             }
+           }
+-        }
+-        if (targetLanguage) {
+-          if (!languageGroups.has(targetLanguage)) {
+-            languageGroups.set(targetLanguage, []);
++          if (targetLanguage) {
++            if (!languageGroups.has(targetLanguage)) {
++              languageGroups.set(targetLanguage, []);
++            }
++            languageGroups.get(targetLanguage).push({ node: capture.node, name: capture.name });
+           }
+-          languageGroups.get(targetLanguage).push({ node: capture.node, name: capture.name });
+         }
+       }
+     }


### PR DESCRIPTION
This PR fixes the issue where HTML tree-sitter injections (e.g., embedded JavaScript and CSS) were not working.

The root cause was that `@opentui/core`'s injection processing logic only iterated over captures, which does not expose properties set by directives like `#set! injection.language "javascript"`. This directive is used by the standard `tree-sitter-html` injection query.

The fix involves:
1.  Patching `node_modules/@opentui/core/parser.worker.js` to iterate over matches and inspect `match.setProperties` to determine the injected language.
2.  Uncommenting the injections configuration in `packages/openhei/parsers-config.ts`.

Verified by reproducing the issue with a script and confirming that `matches()` exposes the necessary properties, and running existing tests to ensure no regressions.


---
*PR created automatically by Jules for task [10851562907528551545](https://jules.google.com/task/10851562907528551545) started by @heidi-dang*