### PR TITLE
Handle context overflow in session processor

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "openhei",

--- a/packages/openhei/src/session/processor.ts
+++ b/packages/openhei/src/session/processor.ts
@@ -354,27 +354,29 @@ export namespace SessionProcessor {
             })
             const error = MessageV2.fromError(e, { providerID: input.model.providerID })
             if (MessageV2.ContextOverflowError.isInstance(error)) {
-              // TODO: Handle context overflow error
-            }
-            const retry = SessionRetry.retryable(error)
-            if (retry !== undefined) {
-              attempt++
-              const delay = SessionRetry.delay(attempt, error.name === "APIError" ? error : undefined)
-              SessionStatus.set(input.sessionID, {
-                type: "retry",
-                attempt,
-                message: retry,
-                next: Date.now() + delay,
+              needsCompaction = true
+              input.assistantMessage.error = error
+            } else {
+              const retry = SessionRetry.retryable(error)
+              if (retry !== undefined) {
+                attempt++
+                const delay = SessionRetry.delay(attempt, error.name === "APIError" ? error : undefined)
+                SessionStatus.set(input.sessionID, {
+                  type: "retry",
+                  attempt,
+                  message: retry,
+                  next: Date.now() + delay,
+                })
+                await SessionRetry.sleep(delay, input.abort).catch(() => {})
+                continue
+              }
+              input.assistantMessage.error = error
+              Bus.publish(Session.Event.Error, {
+                sessionID: input.assistantMessage.sessionID,
+                error: input.assistantMessage.error,
               })
-              await SessionRetry.sleep(delay, input.abort).catch(() => {})
-              continue
+              SessionStatus.set(input.sessionID, { type: "idle" })
             }
-            input.assistantMessage.error = error
-            Bus.publish(Session.Event.Error, {
-              sessionID: input.assistantMessage.sessionID,
-              error: input.assistantMessage.error,
-            })
-            SessionStatus.set(input.sessionID, { type: "idle" })
           }
           if (snapshot) {
             const patch = await Snapshot.patch(snapshot)

--- a/packages/openhei/test/session/processor.test.ts
+++ b/packages/openhei/test/session/processor.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test, mock, beforeAll } from "bun:test"
+import { SessionProcessor } from "../../src/session/processor"
+import { MessageV2 } from "../../src/session/message-v2"
+import { Session } from "../../src/session"
+import { Instance } from "../../src/project/instance"
+import { tmpdir } from "../fixture/fixture"
+import { Identifier } from "../../src/id/id"
+import { LLM } from "../../src/session/llm"
+import { APICallError } from "ai"
+
+// Mock LLM.stream to throw a context overflow error
+mock.module("../../src/session/llm", () => {
+  return {
+    LLM: {
+      stream: async () => {
+        const error = new APICallError({
+            message: "exceeds the context window",
+            url: "http://localhost",
+            requestBody: "{}",
+            responseBody: "{}",
+            statusCode: 400,
+            responseHeaders: {},
+        })
+        throw error
+      },
+    },
+  }
+})
+
+describe("SessionProcessor", () => {
+  test("handles context overflow error by returning 'compact'", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const sessionID = session.id
+        const assistantMessage = await Session.updateMessage({
+          id: Identifier.ascending("message"),
+          sessionID,
+          role: "assistant",
+          agent: "test",
+          mode: "test",
+          modelID: "gpt-4",
+          providerID: "openai",
+          parentID: "parent-id",
+          path: { cwd: "/", root: "/" },
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          time: { created: Date.now() },
+        }) as MessageV2.Assistant
+
+        const processor = SessionProcessor.create({
+          assistantMessage,
+          sessionID,
+          model: {
+            id: "gpt-4",
+            providerID: "openai",
+            api: { id: "openai", npm: "@ai-sdk/openai" },
+            capabilities: {},
+            options: {},
+          } as any,
+          abort: new AbortController().signal,
+        })
+
+        const result = await processor.process({
+            user: {} as any,
+            sessionID,
+            model: {} as any,
+            agent: {} as any,
+            system: [],
+            abort: new AbortController().signal,
+            messages: [],
+            tools: {},
+        })
+
+        // Expected behavior after fix: returns "compact".
+        expect(result).toBe("compact")
+
+        // Also verify the message has the context overflow error set
+        expect(assistantMessage.error).toBeDefined()
+        expect(MessageV2.ContextOverflowError.isInstance(assistantMessage.error)).toBe(true)
+      },
+    })
+  })
+})


### PR DESCRIPTION
Implemented missing handling for `ContextOverflowError` in `SessionProcessor`. When this error occurs (e.g., model context limit exceeded), the processor now:
1.  Sets `needsCompaction = true` to trigger a compaction/summarization cycle.
2.  Sets the error on the assistant message so it is recorded (and skipped in future context).
3.  Breaks the processing loop to return "compact" immediately, avoiding futile retries.

This resolves the TODO in `packages/openhei/src/session/processor.ts`.

Verification:
- Added `packages/openhei/test/session/processor.test.ts` which mocks `LLM.stream` to throw a context overflow error and asserts that `process` returns "compact" and the message has the error set.
- Verified that existing tests pass (ignoring unrelated environment issues in other test files).

---
*PR created automatically by Jules for task [14519350758158513300](https://jules.google.com/task/14519350758158513300) started by @heidi-dang*