### PR TITLE
feat(ui): composer polish (send_option semantics + tests)

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1291,7 +1291,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                     options={["default", "no_reply", "priority"]}
                     current={"default"}
                     onSelect={(value) => {
-                      ;(window as any).__prompt_selected_send_option = value
+                      setSelectedSendOption(value === "default" ? undefined : value)
                     }}
                     aria-label="Send options"
                     variant="ghost"

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -274,9 +274,6 @@ describe("prompt submit stale session recovery", () => {
   })
 
   test("attaches send_option metadata when select is present", async () => {
-    // For tests, we provide the selected send option by setting the test hook
-    // that createPromptSubmit reads. This is isolated to the test runtime.
-    ;(globalThis as any).__prompt_selected_send_option = "no_reply"
     params = { id: "ses_ok", dir: "/repo/main" }
     const submit = createPromptSubmit({
       info: () => undefined,
@@ -292,6 +289,7 @@ describe("prompt submit stale session recovery", () => {
       setMode: () => undefined,
       setPopover: () => undefined,
       onSubmit: () => undefined,
+      selectedSendOption: () => "no_reply",
     })
 
     const event = { preventDefault: () => undefined } as unknown as Event
@@ -301,7 +299,6 @@ describe("prompt submit stale session recovery", () => {
     const call = promptAsyncCalls[promptAsyncCalls.length - 1]
     const textPart = call.input.parts.find((p: any) => p.type === "text")
     expect(textPart.metadata?.send_option).toBe("no_reply")
-    delete (globalThis as any).__prompt_selected_send_option
   })
 
   test("selectedSendOption accessor is used when provided", async () => {

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -381,11 +381,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     // The selected send option is provided by the PromptInput component when
     // creating the submit handler. If no option is supplied, it will be
     // undefined and omitted from the metadata.
-    // NOTE: production code should NOT read from the DOM or global test hooks.
-    // First prefer selectedSendOption provided explicitly via input (preferred)
-    const selectedSendOption = input.selectedSendOption
-      ? input.selectedSendOption()
-      : ((window as any).__prompt_selected_send_option ?? undefined)
+    const selectedSendOption = input.selectedSendOption?.()
 
     const { requestParts, optimisticParts } = buildRequestParts({
       prompt: currentPrompt,


### PR DESCRIPTION
### Issue for this PR

Closes #40

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Unifies send_option plumbing in PromptInput:
- Single-source-of-truth: `selectedSendOption` signal in PromptInput is now the only source
- Both palette (ui.composer_palette) and dropdown (ui.send_options) write to the same signal
- Removed production global `window.__prompt_selected_send_option` fallback
- Updated test to use explicit `selectedSendOption` accessor instead of global

### How did you verify your code works?

- `bun turbo typecheck` passes
- `bun --cwd packages/app test` passes (262 tests)
- `bun --cwd packages/app build` succeeds

### Screenshots / recordings

_N/A - no UI changes_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
