### PR TITLE
chore(ui): phase5 foundations (flags hygiene + docs + guardrails)

### DIFF
--- a/docs/phase5-foundations.md
+++ b/docs/phase5-foundations.md
@@ -1,0 +1,22 @@
+Phase 5 — Foundations
+
+This small doc summarizes the Phase 5 foundations work (P5-1). It is intentionally
+short and non-prescriptive: the goal is hygiene and guardrails around feature
+flags and docs, without behavioral changes.
+
+Scope
+
+- flags hygiene only (no behavior changes)
+- short note for Phase 5 foundations
+- small guardrails: a lightweight unit test ensuring all flags default to OFF
+
+Acceptance
+
+- branch created from latest `main` (fast-forward)
+- all flags default OFF in `DEFAULT_SETTINGS`
+- typecheck/tests/build pass
+
+Notes
+
+- Keep feature flags OFF by default. Tests should assert defaults rather than
+  assume a stateful environment.

--- a/packages/app/src/context/settings.test.ts
+++ b/packages/app/src/context/settings.test.ts
@@ -1,0 +1,12 @@
+import { test, expect } from "bun:test"
+import { DEFAULT_SETTINGS } from "./settings"
+
+test("all ui flags default to false", () => {
+  const flags = DEFAULT_SETTINGS.flags
+  const keys = Object.keys(flags)
+  expect(keys.length).toBeGreaterThan(0)
+  for (const k of keys) {
+    // @ts-ignore - dynamic key access for test
+    expect((flags as any)[k]).toBe(false)
+  }
+})


### PR DESCRIPTION
## Summary\n- Add docs: docs/phase5-foundations.md\n- Add guard test: packages/app/src/context/settings.test.ts asserting DEFAULT_SETTINGS UI flags default false\n- Export DEFAULT_SETTINGS for verification/docs only (no runtime behavior change)\n\n## Verification\n- bun turbo typecheck\n- bun --cwd packages/app test\n- bun --cwd packages/app build\n\n## Notes\n- DEFAULT_SETTINGS export is read-only, intended for tests/docs\n- No behavior changes; flags remain OFF by default\n\n## Manual\n- N/A (docs + test only)