### PR TITLE
fix(openhei): import @opentui/solid/bun-plugin

### DIFF
--- a/packages/openhei/script/build.ts
+++ b/packages/openhei/script/build.ts
@@ -4,7 +4,10 @@ import { $ } from "bun"
 import fs from "fs"
 import path from "path"
 import { fileURLToPath } from "url"
-import solidPlugin from "../node_modules/@opentui/solid/scripts/solid-plugin"
+import solidPlugin from "@opentui/solid/bun-plugin"
+import { createRequire } from "module"
+
+const require = createRequire(import.meta.url)
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -76,13 +79,13 @@ const migrations = await Promise.all(
     const match = /^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/.exec(name)
     const timestamp = match
       ? Date.UTC(
-          Number(match[1]),
-          Number(match[2]) - 1,
-          Number(match[3]),
-          Number(match[4]),
-          Number(match[5]),
-          Number(match[6]),
-        )
+        Number(match[1]),
+        Number(match[2]) - 1,
+        Number(match[3]),
+        Number(match[4]),
+        Number(match[5]),
+        Number(match[6]),
+      )
       : 0
     return { sql, timestamp }
   }),
@@ -95,66 +98,66 @@ const allTargets: {
   abi?: "musl"
   avx2?: false
 }[] = [
-  {
-    os: "linux",
-    arch: "arm64",
-  },
-  {
-    os: "linux",
-    arch: "x64",
-  },
-  {
-    os: "linux",
-    arch: "x64",
-    avx2: false,
-  },
-  {
-    os: "linux",
-    arch: "arm64",
-    abi: "musl",
-  },
-  {
-    os: "linux",
-    arch: "x64",
-    abi: "musl",
-  },
-  {
-    os: "linux",
-    arch: "x64",
-    abi: "musl",
-    avx2: false,
-  },
-  {
-    os: "darwin",
-    arch: "arm64",
-  },
-  {
-    os: "darwin",
-    arch: "x64",
-  },
-  {
-    os: "darwin",
-    arch: "x64",
-    avx2: false,
-  },
-  {
-    os: "win32",
-    arch: "x64",
-  },
-  {
-    os: "win32",
-    arch: "x64",
-    avx2: false,
-  },
-]
+    {
+      os: "linux",
+      arch: "arm64",
+    },
+    {
+      os: "linux",
+      arch: "x64",
+    },
+    {
+      os: "linux",
+      arch: "x64",
+      avx2: false,
+    },
+    {
+      os: "linux",
+      arch: "arm64",
+      abi: "musl",
+    },
+    {
+      os: "linux",
+      arch: "x64",
+      abi: "musl",
+    },
+    {
+      os: "linux",
+      arch: "x64",
+      abi: "musl",
+      avx2: false,
+    },
+    {
+      os: "darwin",
+      arch: "arm64",
+    },
+    {
+      os: "darwin",
+      arch: "x64",
+    },
+    {
+      os: "darwin",
+      arch: "x64",
+      avx2: false,
+    },
+    {
+      os: "win32",
+      arch: "x64",
+    },
+    {
+      os: "win32",
+      arch: "x64",
+      avx2: false,
+    },
+  ]
 
 const targets = singleFlag
   ? allTargets.filter((item) => {
-      if (item.os !== process.platform || item.arch !== process.arch) return false
-      if (item.avx2 === false) return baselineFlag
-      if (item.abi !== undefined) return false
-      return true
-    })
+    if (item.os !== process.platform || item.arch !== process.arch) return false
+    if (item.avx2 === false) return baselineFlag
+    if (item.abi !== undefined) return false
+    return true
+  })
   : allTargets
 
 if (skipDashboard) {
@@ -191,7 +194,7 @@ for (const item of targets) {
   await $`mkdir -p dist/${name}/bin`
   await $`cp -r ../../packages/app/dist dist/${name}/dashboard`
 
-  const parserWorker = fs.realpathSync(path.resolve(dir, "./node_modules/@opentui/core/parser.worker.js"))
+  const parserWorker = fs.realpathSync(path.join(path.dirname(require.resolve("@opentui/core/package.json")), "parser.worker.js"))
   const workerPath = "./src/cli/cmd/tui/worker.ts"
 
   // Use platform-specific bunfs root path based on target OS


### PR DESCRIPTION
## Summary

Fixes node_modules hoisting breaking local repo builds by replacing explicit paths with proper export resolutions for solid-plugin and parser.worker.js.

## Problem

When node_modules are hoisted (for example by certain package managers or monorepo setups), the build script in packages/openhei/script/build.ts fails to resolve @opentui/solid/bun-plugin and parser.worker.js via direct file paths. This causes ./install.sh --repo-local to fail.

## Solution

- Replace explicit hoisted paths with package export resolutions.
- Use resolved package entrypoints so Bun/Node resolves the correct files regardless of hoisting.

## Test Plan

1. Run ./install.sh -repo-local --no-modify-path in a hoisted setup.
2. Confirm build completes and binary is produced in dist/*.
3. CI should cover both hoisted and non-hoisted scenarios.

## Related

Closes #63

## Notes

This PR is blocked by org labels (needs:issue + needs:compliance) which may auto-close this PR. Please keep this open until checks pass and merge it when green.

