### PR TITLE
feat(settings): add Experimental section with Phase 5 flag toggles

### DIFF
--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -315,6 +315,64 @@ export const SettingsGeneral: Component = () => {
     </div>
   )
 
+  const ExperimentalSection = () => (
+    <div class="flex flex-col gap-1">
+      <h3 class="text-14-medium text-text-strong pb-2">{language.t("settings.general.section.experimental")}</h3>
+
+      <div class="bg-surface-raised-base px-4 rounded-lg">
+        <SettingsRow
+          title={language.t("settings.general.row.sendOptions.title")}
+          description={language.t("settings.general.row.sendOptions.description")}
+        >
+          <Switch
+            checked={settings.flags.get("ui.send_options")}
+            onChange={(checked) => settings.flags.set("ui.send_options", checked)}
+          />
+        </SettingsRow>
+
+        <SettingsRow
+          title={language.t("settings.general.row.composerPalette.title")}
+          description={language.t("settings.general.row.composerPalette.description")}
+        >
+          <Switch
+            checked={settings.flags.get("ui.composer_palette")}
+            onChange={(checked) => settings.flags.set("ui.composer_palette", checked)}
+          />
+        </SettingsRow>
+
+        <SettingsRow
+          title={language.t("settings.general.row.draftPersist.title")}
+          description={language.t("settings.general.row.draftPersist.description")}
+        >
+          <Switch
+            checked={settings.flags.get("ui.draft_persist")}
+            onChange={(checked) => settings.flags.set("ui.draft_persist", checked)}
+          />
+        </SettingsRow>
+
+        <SettingsRow
+          title={language.t("settings.general.row.thinkingDrawer.title")}
+          description={language.t("settings.general.row.thinkingDrawer.description")}
+        >
+          <Switch
+            checked={settings.flags.get("ui.thinking_drawer")}
+            onChange={(checked) => settings.flags.set("ui.thinking_drawer", checked)}
+          />
+        </SettingsRow>
+
+        <SettingsRow
+          title={language.t("settings.general.row.densityModes.title")}
+          description={language.t("settings.general.row.densityModes.description")}
+        >
+          <Switch
+            checked={settings.flags.get("ui.density_modes")}
+            onChange={(checked) => settings.flags.set("ui.density_modes", checked)}
+          />
+        </SettingsRow>
+      </div>
+    </div>
+  )
+
   const NotificationsSection = () => (
     <div class="flex flex-col gap-1">
       <h3 class="text-14-medium text-text-strong pb-2">{language.t("settings.general.section.notifications")}</h3>
@@ -466,6 +524,8 @@ export const SettingsGeneral: Component = () => {
 
       <div class="flex flex-col gap-8 w-full">
         <AppearanceSection />
+
+        <ExperimentalSection />
 
         <NotificationsSection />
 

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -609,6 +609,18 @@ export const dict = {
   "settings.general.section.updates": "Updates",
   "settings.general.section.sounds": "Sound effects",
   "settings.general.section.display": "Display",
+  "settings.general.section.experimental": "Experimental",
+
+  "settings.general.row.sendOptions.title": "Send options",
+  "settings.general.row.sendOptions.description": "Show send options dropdown in composer (plan, no reply, priority)",
+  "settings.general.row.composerPalette.title": "Composer palette",
+  "settings.general.row.composerPalette.description": "Enable / command palette with keyboard navigation",
+  "settings.general.row.draftPersist.title": "Draft persistence",
+  "settings.general.row.draftPersist.description": "Save draft messages and restore on page reload",
+  "settings.general.row.thinkingDrawer.title": "Thinking drawer",
+  "settings.general.row.thinkingDrawer.description": "Show reasoning/thinking drawer for assistant messages",
+  "settings.general.row.densityModes.title": "Density modes",
+  "settings.general.row.densityModes.description": "Enable compact and comfortable density modes",
 
   "settings.general.row.language.title": "Language",
   "settings.general.row.language.description": "Change the display language for OpenHei",


### PR DESCRIPTION
## Summary
Exposes Phase 5 feature flags in the Settings UI so users can enable features without editing localStorage.

## Changes
- Added "Experimental" section in Settings > General with toggle switches for:
  - Send options (ui.send_options)
  - Composer palette (ui.composer_palette) 
  - Draft persistence (ui.draft_persist)
  - Thinking drawer (ui.thinking_drawer)
  - Density modes (ui.density_modes)
- All flags default to OFF (existing behavior preserved)
- Added English translations for the new settings

## What did not change
- Flag defaults remain OFF
- No behavior changes when flags are OFF
- No new dependencies

## Verification
- bun turbo typecheck
- bun --cwd packages/app test (263 pass, 0 fail)
- bun --cwd packages/app build

## Files
- packages/app/src/components/settings-general.tsx (added ExperimentalSection)
- packages/app/src/i18n/en.ts (added translations)

## Manual Mobile Checklist
- [ ] Open Settings on iPhone Safari
- [ ] Verify Experimental section appears
- [ ] Toggle each flag and verify no horizontal scroll
- [ ] Verify toggles work without layout shift
