### PR TITLE
test(a11y): add aria-label to thinking drawer + update docs

### DIFF
--- a/docs/phase5-verify.md
+++ b/docs/phase5-verify.md
@@ -80,11 +80,31 @@ location.reload()
 
 ### ui.thinking_drawer
 
-1. Enable the flag as described above
-2. Reload the page
-3. Send a prompt that triggers a reasoning/thinking response
-4. Verify a drawer expands below the message showing thinking/reasoning
-5. Verify it can be collapsed/expanded
+The thinking drawer shows model reasoning/thinking before the final response.
+
+**Manual verification steps:**
+
+1. **Flag OFF (default):**
+   - With flag OFF, no drawer button should appear on any message
+   - Verify by disabling the flag and checking messages show no "Thinking" trigger
+
+2. **Flag ON + mode = auto:**
+   - Enable the flag in Settings > Experimental
+   - Set thinking drawer mode to "auto"
+   - Send a prompt that triggers reasoning
+   - Verify: drawer button shows with duration (e.g., "Thinking 3.2s")
+   - Click/press Enter to expand - summary content appears
+   - Click again to collapse
+
+3. **Flag ON + mode = always:**
+   - Set thinking drawer mode to "always"
+   - Verify drawer button appears even without reasoning_summary
+   - (Duration shows "0s" or similar when no timing data)
+
+4. **Keyboard accessibility:**
+   - Tab to drawer trigger
+   - Press Enter or Space - should toggle open/close
+   - Screen reader should announce "Thinking, expanded/collapsed"
 
 ### ui.density_modes
 

--- a/packages/ui/src/components/thinking-drawer.tsx
+++ b/packages/ui/src/components/thinking-drawer.tsx
@@ -34,6 +34,7 @@ export const ThinkingDrawer: Component<Props> = (props) => {
         tabIndex={0}
         aria-expanded={open()}
         aria-controls={`${props.id}-content`}
+        aria-label={i18n.t("ui.sessionTurn.status.thinking")}
         data-slot="thinking-drawer-trigger"
         onClick={() => setOpen(!open())}
         onKeyDown={onKeyDown}


### PR DESCRIPTION
## Summary
Adds accessibility improvements and documentation for the Thinking Drawer feature.

## Changes
1. **Accessibility:**
   - Added  to the thinking drawer trigger button for screen reader support
   - Already had: , , , , keyboard handlers for Enter/Space

2. **Documentation:**
   - Updated docs/phase5-verify.md with detailed 3-step manual verification for thinking drawer:
     - Flag OFF check
     - Flag ON + mode = auto check
     - Flag ON + mode = always check
     - Keyboard accessibility check

3. **Tests:**
   - Existing tests in packages/ui already cover:
     - Gating: flag OFF => no drawer
     - Mode never prevents rendering
     - Mode always renders regardless
     - Mode auto renders only with safe summary
     - getReasoningSummary handles snake/camel/metadata
     - computeReasoningDuration formats correctly

## What did not change
- No behavior changes when flag is OFF
- No new dependencies

## Verification
- bun turbo typecheck
- bun --cwd packages/app test (263 pass)
- bun --cwd packages/ui test (6 pass)

## Files
- packages/ui/src/components/thinking-drawer.tsx (added aria-label)
- docs/phase5-verify.md (updated manual checklist)

## Manual Mobile Checklist
- [ ] Test thinking drawer on iPhone Safari
- [ ] Verify tap to expand/collapse works
- [ ] Verify no horizontal scroll when drawer opens
