### PR TITLE
feat(palette): mobile polish - tap outside dismiss + scroll into view

### DIFF
--- a/docs/phase5-verify.md
+++ b/docs/phase5-verify.md
@@ -56,16 +56,30 @@ location.reload()
 
 ### ui.composer_palette
 
-1. Enable the flag as described above
+The slash command palette lets you quickly select send options (/plan, /act, /explain, /search) from the composer.
+
+**Desktop verification:**
+
+1. Enable the flag in Settings > Experimental
 2. Reload the page
 3. Focus on the composer input
 4. Type `/` at the start of the input
 5. Verify a palette appears with commands: `/plan`, `/act`, `/explain`, `/search`
-6. Use arrow keys to navigate (up/down)
+6. Use arrow keys to navigate (up/down) - active item scrolls into view
 7. Press Enter or Tab to select a command
 8. Verify the command prefix is stripped from the text
 9. Press Escape to close the palette
-10. Mobile: Tap a command to select it
+
+**Mobile (iPhone Safari) verification:**
+
+1. Enable the flag in Settings > Experimental
+2. Reload the page
+3. Tap composer to focus
+4. Type `/` - palette should appear under composer (no layout shift)
+5. Scroll palette list (if long) - smooth scroll, no page hijack
+6. Tap outside palette - should close reliably
+7. Tap an option - closes palette, strips `/cmd ` prefix, keeps remainder
+8. No horizontal scroll should occur at any point
 
 ### ui.draft_persist
 

--- a/packages/app/src/components/prompt-input/palette.tsx
+++ b/packages/app/src/components/prompt-input/palette.tsx
@@ -51,22 +51,50 @@ export function stripSlashPrefix(text: string, cmd: string) {
 
 export default function Palette(props: { palette: ReturnType<typeof createPalette>; onSelect: (cmd: string) => void }) {
   const p = props.palette
+  let listRef: HTMLDivElement | undefined
+
+  createEffect(() => {
+    const idx = p.activeIndex()
+    if (!listRef) return
+    const items = listRef.querySelectorAll("[data-palette-item]")
+    const el = items[idx] as HTMLElement | undefined
+    if (el) {
+      el.scrollIntoView({ block: "nearest", behavior: "auto" })
+    }
+  })
+
   return (
-    <div class="absolute left-2 top-full z-50 max-h-[200px] w-[calc(100%-1rem)] sm:w-[260px] overflow-y-auto bg-surface-1 border border-divider rounded shadow-md mt-1 sm:left-0">
-      <div class="p-1">
-        {p.filtered().map((cmd, idx) => (
-          <div
-            classList={{
-              "px-3 py-2.5 rounded min-h-[44px] flex items-center": true,
-              "bg-surface-2": idx === p.activeIndex(),
-            }}
-            onMouseEnter={() => p.setActiveIndex(idx)}
-            onClick={() => props.onSelect(cmd.id)}
-          >
-            <span class="text-14-regular">{cmd.title}</span>
-          </div>
-        ))}
+    <>
+      <div
+        class="fixed inset-0 z-40"
+        onClick={(e) => {
+          e.stopPropagation()
+          p.setOpen(false)
+        }}
+      />
+      <div
+        ref={listRef}
+        class="absolute left-2 top-full z-50 max-h-[200px] w-[calc(100%-1rem)] sm:w-[260px] overflow-y-auto bg-surface-1 border border-divider rounded shadow-md mt-1 sm:left-0"
+      >
+        <div class="p-1">
+          {p.filtered().map((cmd, idx) => (
+            <div
+              data-palette-item
+              classList={{
+                "px-3 py-2.5 rounded min-h-[44px] flex items-center cursor-pointer": true,
+                "bg-surface-2": idx === p.activeIndex(),
+              }}
+              onMouseEnter={() => p.setActiveIndex(idx)}
+              onClick={(e) => {
+                e.stopPropagation()
+                props.onSelect(cmd.id)
+              }}
+            >
+              <span class="text-14-regular">{cmd.title}</span>
+            </div>
+          ))}
+        </div>
       </div>
-    </div>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
Improves the composer slash palette UX for mobile (iPhone Safari) and accessibility.

## Changes

### 1. Tap Outside to Dismiss (Mobile-First)
- Added a fixed fullscreen backdrop behind the palette
- Tapping backdrop closes the palette
- Clicks inside palette use stopPropagation to prevent backdrop from closing
- Only renders when palette is open (gated by ui.composer_palette flag)

### 2. Active Item Scrolls Into View
- Added scrollIntoView on activeIndex change during keyboard navigation
- Uses block: "nearest" for smooth scroll behavior
- Guarded with ref check to prevent errors if element not found

### 3. Touch Target Polish
- Added cursor-pointer to palette items for visual feedback
- Added data-palette-item attribute for reliable querying in scroll logic
- Touch targets already at 44px min-height (min-h-[44px])

## What Did Not Change
- No new dependencies
- No backend changes
- Flag OFF => zero behavior/UI changes
- Palette opens/closes logic unchanged (still reacts to '/' prefix)
- Send option is metadata-only (no backend changes)

## Verification
- bun turbo typecheck
- bun --cwd packages/app test (263 pass)
- bun --cwd packages/app build

## Files
- packages/app/src/components/prompt-input/palette.tsx (added backdrop, scrollIntoView, stopPropagation)
- docs/phase5-verify.md (added mobile checklist)

## Manual Mobile Checklist (iPhone Safari)
- [ ] Enable Experimental > Composer palette
- [ ] Tap composer, type / => palette appears under composer (no layout shift)
- [ ] Scroll palette list (if long) => smooth scroll, no page hijack
- [ ] Tap outside palette => closes reliably
- [ ] Tap an option => closes + strips /cmd prefix, keeps remainder text
