### PR TITLE
feat(persistence): draft stale policy (7d)

### DIFF
--- a/docs/phase5-verify.md
+++ b/docs/phase5-verify.md
@@ -92,6 +92,16 @@ The slash command palette lets you quickly select send options (/plan, /act, /ex
 7. Click "Restore" - verify the text is restored
 8. Click "Discard" - verify the text is cleared
 
+#### Draft stale policy (new)
+
+1. Ensure `ui.draft_persist` is enabled and reload
+2. Create a draft in the composer (do not send)
+3. In DevTools > Application > Local Storage, find the key starting with `draft.v2.` and edit its `ts_ms` to a timestamp older than 7 days
+4. Reload the page - the "Restore draft?" banner should NOT appear
+5. Confirm the stale key is removed from localStorage (best-effort)
+6. Create a fresh draft and reload - the banner should appear and restoring should populate the composer
+7. Verify overlay behavior on mobile (no layout shift)
+
 ### ui.thinking_drawer
 
 The thinking drawer shows model reasoning/thinking before the final response.

--- a/packages/app/src/components/prompt-input/draft-persist.test.ts
+++ b/packages/app/src/components/prompt-input/draft-persist.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, test } from "bun:test"
+
+class MemoryStorage implements Storage {
+  private values = new Map<string, string>()
+  clear() {
+    this.values.clear()
+  }
+  get length() {
+    return this.values.size
+  }
+  key(i: number) {
+    return Array.from(this.values.keys())[i] ?? null
+  }
+  getItem(key: string) {
+    return this.values.get(key) ?? null
+  }
+  setItem(key: string, value: string) {
+    this.values.set(key, value)
+  }
+  removeItem(key: string) {
+    this.values.delete(key)
+  }
+}
+
+const storage = new MemoryStorage()
+
+beforeEach(() => {
+  storage.clear()
+  Object.defineProperty(globalThis, "localStorage", { value: storage, configurable: true })
+})
+
+describe("draft persist v2 stale policy", () => {
+  test("fresh draft is restored", () => {
+    const mod = require("./draft-persist")
+    const key = mod.draftKey("ws", "sid")
+    const payload = JSON.stringify({ text: "abc", ts_ms: Date.now() })
+    localStorage.setItem(key, payload)
+    const got = mod.readDraft(key)
+    expect(got).toBe("abc")
+  })
+
+  test("stale draft is ignored and removed", () => {
+    const mod = require("./draft-persist")
+    const key = mod.draftKey("ws", "sid")
+    const payload = JSON.stringify({ text: "old", ts_ms: Date.now() - (mod.STALE_MS + 1000) })
+    localStorage.setItem(key, payload)
+    const got = mod.readDraft(key)
+    expect(got).toBeUndefined()
+    expect(localStorage.getItem(key)).toBeNull()
+  })
+
+  test("invalid JSON returns undefined", () => {
+    const mod = require("./draft-persist")
+    const key = mod.draftKey("ws", "sid")
+    localStorage.setItem(key, "not-json")
+    const got = mod.readDraft(key)
+    expect(got).toBeUndefined()
+  })
+})

--- a/packages/app/src/components/prompt-input/draft-persist.ts
+++ b/packages/app/src/components/prompt-input/draft-persist.ts
@@ -1,14 +1,36 @@
 import { Persist } from "@/utils/persist"
 
+// Draft persistence v2: store JSON { text: string, ts_ms: number }
+// Stale policy: ignore drafts older than 7 days
 const sanitize = (v: string) => v.replace(/[\s\/\\]/g, "-")
 
+export const STALE_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
+
 export const draftKey = (workspaceId: string, sessionId?: string) =>
-  `draft.v1.${sanitize(workspaceId)}.${sanitize(sessionId ?? "root")}`
+  `draft.v2.${sanitize(workspaceId)}.${sanitize(sessionId ?? "root")}`
 
 export const readDraft = (key: string) => {
   try {
-    const item = localStorage.getItem(key)
-    return item ?? undefined
+    const raw = localStorage.getItem(key)
+    if (!raw) return undefined
+    let parsed: { text?: string; ts_ms?: number } | undefined
+    try {
+      parsed = JSON.parse(raw)
+    } catch (e) {
+      // malformed payload - best-effort: do not throw, treat as no draft
+      return undefined
+    }
+    if (!parsed || typeof parsed.text !== "string" || typeof parsed.ts_ms !== "number") return undefined
+    if (Date.now() - parsed.ts_ms > STALE_MS) {
+      // best-effort remove stale entry
+      try {
+        localStorage.removeItem(key)
+      } catch (e) {
+        // ignore
+      }
+      return undefined
+    }
+    return parsed.text
   } catch (e) {
     return undefined
   }
@@ -16,7 +38,8 @@ export const readDraft = (key: string) => {
 
 export const writeDraft = (key: string, value: string) => {
   try {
-    localStorage.setItem(key, value)
+    const payload = JSON.stringify({ text: value, ts_ms: Date.now() })
+    localStorage.setItem(key, payload)
   } catch (e) {
     // best-effort
   }


### PR DESCRIPTION
Summary:\n- Add stale policy for draft persistence (ignore drafts older than 7 days).\n- Version bump draft key to draft.v2.* storing {text, ts_ms}.\nSafety:\n- Flag ui.draft_persist remains OFF by default.\n- Best-effort localStorage access (never throws).\nTests:\n- Added unit tests for fresh/stale/invalid draft handling.\nManual checks:\n- iPhone Safari: no layout shift; restore banner is overlay-only.