### PR TITLE
feat(ui): whats-new entrypoint for Experimental

### DIFF
--- a/docs/phase5-verify.md
+++ b/docs/phase5-verify.md
@@ -3,3 +3,9 @@
 1. Enable flag: Settings > General > Experimental: enable `Send options`, then reload.
 2. Desktop: open a session, pick a non-default option (e.g. "Plan" or "No reply") and send a message — verify the outgoing request parts include `metadata.send_option` with the chosen value. Switch back to "Default" and send — verify `metadata.send_option` is absent.
 3. iPhone Safari: confirm dropdown touch target is >=44px tall, no horizontal scroll (`document.documentElement.scrollWidth === window.innerWidth`), and selection persists after reload.
+
+## What's New Banner (dismissedWhatsNewPhase5)
+
+1. Fresh user (or after `settings.v3` cleared): verify the "What's New" banner appears at the top of the app after login, pointing to Settings → General → Experimental.
+2. Click "Open Settings": navigate to the Settings page. Verify the banner disappears immediately.
+3. Reload the page: confirm the banner does NOT reappear (dismissal persisted via settings store).

--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -7,8 +7,9 @@ import { MarkedProvider } from "@openhei-ai/ui/context/marked"
 import { Font } from "@openhei-ai/ui/font"
 import { ThemeProvider } from "@openhei-ai/ui/theme"
 import { MetaProvider } from "@solidjs/meta"
-import { Navigate, Route, Router } from "@solidjs/router"
+import { Navigate, Route, Router, useNavigate } from "@solidjs/router"
 import { ErrorBoundary, type JSX, lazy, type ParentProps, Show, Suspense } from "solid-js"
+import { Button } from "@openhei-ai/ui/button"
 import { CommandProvider } from "@/context/command"
 import { CommentsProvider } from "@/context/comments"
 import { FileProvider } from "@/context/file"
@@ -113,7 +114,36 @@ function DensityRootWrapper(props: ParentProps) {
 
   return (
     <div class="density-root" data-density={density}>
+      <Show when={settings && !settings.general.dismissedWhatsNewPhase5()}>
+        <WhatsNewPhase5Banner onDismiss={() => settings!.general.setDismissedWhatsNewPhase5(true)} />
+      </Show>
       {props.children}
+    </div>
+  )
+}
+
+function WhatsNewPhase5Banner(props: { onDismiss: () => void }) {
+  const language = useLanguage()
+  const navigate = useNavigate()
+
+  const openSettings = () => {
+    navigate("/settings")
+  }
+
+  return (
+    <div class="fixed top-0 left-0 right-0 z-50 bg-surface-3 border-b border-border-weak-base px-4 py-3 flex items-center gap-3 shadow-md">
+      <div class="flex-1 min-w-0">
+        <div class="text-13-medium text-text-strong">{language.t("whatsNew.phase5.title")}</div>
+        <div class="text-12-regular text-text-weak truncate">{language.t("whatsNew.phase5.description")}</div>
+      </div>
+      <div class="flex items-center gap-2 shrink-0">
+        <Button size="small" variant="primary" onClick={openSettings}>
+          {language.t("whatsNew.phase5.openSettings")}
+        </Button>
+        <Button size="small" variant="ghost" onClick={props.onDismiss}>
+          {language.t("whatsNew.phase5.dismiss")}
+        </Button>
+      </div>
     </div>
   )
 }

--- a/packages/app/src/context/settings.test.ts
+++ b/packages/app/src/context/settings.test.ts
@@ -18,3 +18,8 @@ test("density default is comfortable and flag is off", () => {
   expect(DEFAULT_SETTINGS.general.density).toBe("comfortable")
   expect(DEFAULT_SETTINGS.flags["ui.density_modes"]).toBe(false)
 })
+
+test("whatsNewPhase5 dismissal defaults to false", () => {
+  // The What's New banner should appear by default (not dismissed).
+  expect(DEFAULT_SETTINGS.general.dismissedWhatsNewPhase5).toBe(false)
+})

--- a/packages/app/src/context/settings.tsx
+++ b/packages/app/src/context/settings.tsx
@@ -30,6 +30,8 @@ export interface Settings {
     sendOption?: "default" | "no_reply" | "plan" | "act" | "explain" | "search" | "priority"
     // Dismissed flag for an experimental discovery notice in Settings UI.
     dismissedExperimentalNotice?: boolean
+    // Dismissed flag for the Phase 5 "What's new" banner.
+    dismissedWhatsNewPhase5?: boolean
     // Controls how the thinking/summary drawer behaves when the feature is enabled.
     // This is a user preference only - the feature gate remains `flags["ui.thinking_drawer"]`.
     // Allowed values:
@@ -75,6 +77,7 @@ const defaultSettings: Settings = {
     autoSave: true,
     releaseNotes: true,
     dismissedExperimentalNotice: false,
+    dismissedWhatsNewPhase5: false,
     sendOption: "default",
     showReasoningSummaries: false,
     density: "comfortable",
@@ -221,6 +224,13 @@ export const { use: useSettings, provider: SettingsProvider } = createSimpleCont
         ),
         setDismissedExperimentalNotice(value: boolean) {
           setStore("general", "dismissedExperimentalNotice", value)
+        },
+        dismissedWhatsNewPhase5: withFallback(
+          () => store.general?.dismissedWhatsNewPhase5 as boolean | undefined,
+          false,
+        ),
+        setDismissedWhatsNewPhase5(value: boolean) {
+          setStore("general", "dismissedWhatsNewPhase5", value)
         },
         setSendOption(value: "default" | "no_reply" | "plan" | "act" | "explain" | "search" | "priority") {
           setStore("general", "sendOption", value)

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -617,6 +617,12 @@ export const dict = {
   "settings.general.experimental.notice.description":
     "Try new composer features like Send Options and Composer Palette. These are off by default and available under Experimental.",
   "settings.general.experimental.notice.dismiss": "Dismiss",
+
+  "whatsNew.phase5.title": "New: Phase 5 Experimental Features",
+  "whatsNew.phase5.description":
+    "Thinking Drawer, Send Options, Slash Palette, Draft Persist, and Density Modes are now available. Enable them in Settings → General → Experimental.",
+  "whatsNew.phase5.openSettings": "Open Settings",
+  "whatsNew.phase5.dismiss": "Dismiss",
   "prompt.sendOptions.option.default": "Default",
   "prompt.sendOptions.option.no_reply": "No reply",
   "prompt.sendOptions.option.plan": "Plan",


### PR DESCRIPTION
- Adds a one-time Phase 5 'What\'s new' notice pointing to Settings → General → Experimental.\n- Persisted via settings store (default OFF/hidden after dismiss).\n- No backend changes, no new deps.\n- Verification: bun turbo typecheck; bun –cwd packages/app test; bun –cwd packages/app build.\n- Manual: mobile Safari/no horizontal scroll; touch targets >=44px; dismiss persists.