### PR TITLE
feat(chat-mode): enforce Chat-only — strip agent/tool parts, block to…

### DIFF
--- a/packages/app/src/components/dialog-select-model.tsx
+++ b/packages/app/src/components/dialog-select-model.tsx
@@ -14,6 +14,7 @@ import { DialogSelectProvider } from "./dialog-select-provider"
 import { DialogManageModels } from "./dialog-manage-models"
 import { ModelTooltip } from "./model-tooltip"
 import { useLanguage } from "@/context/language"
+import { useGlobalSync } from "@/context/global-sync"
 
 const isFree = (provider: string, cost: { input: number } | undefined) =>
   provider === "openhei" && (!cost || cost.input === 0)

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -169,6 +169,16 @@ beforeAll(async () => {
     }),
   }))
 
+  // Provide a default settings mock; tests can override by remocking if needed
+  mock.module("@/context/settings", () => ({
+    useSettings: () => ({
+      general: {
+        chatMode: () => "agent",
+        setChatMode: (v: string) => undefined,
+      },
+    }),
+  }))
+
   const mod = await import("./submit")
   createPromptSubmit = mod.createPromptSubmit
 })
@@ -299,6 +309,76 @@ describe("prompt submit stale session recovery", () => {
     const call = promptAsyncCalls[promptAsyncCalls.length - 1]
     const textPart = call.input.parts.find((p: any) => p.type === "text")
     expect(textPart.metadata?.send_option).toBe("no_reply")
+  })
+
+  test("chat-only mode strips agent/tools and parts", async () => {
+    // Remock settings to return chat_only
+    mock.module("@/context/settings", () => ({
+      useSettings: () => ({
+        general: {
+          chatMode: () => "chat_only",
+          setChatMode: (v: string) => undefined,
+        },
+      }),
+    }))
+
+    // re-import the module to pick up new mock
+    const mod = await import("./submit")
+    const createPromptSubmitLocal = mod.createPromptSubmit
+
+    params = { id: "ses_ok", dir: "/repo/main" }
+
+    // Provide a prompt that would include an agent part if not stripped
+    const promptWithAgent: Prompt = [
+      { type: "text", content: "Hello", start: 0, end: 5 },
+      { type: "agent", name: "agentX", content: "run", start: 6, end: 9 } as any,
+    ]
+
+    // Remock prompt to return our special prompt
+    mock.module("@/context/prompt", () => ({
+      usePrompt: () => ({
+        current: () => promptWithAgent,
+        reset: () => undefined,
+        set: () => undefined,
+        context: {
+          add: () => undefined,
+          remove: () => undefined,
+          items: () => [],
+        },
+      }),
+    }))
+
+    const submit = createPromptSubmitLocal({
+      info: () => undefined,
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      mode: () => "normal",
+      working: () => false,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      onSubmit: () => undefined,
+    })
+
+    const event = { preventDefault: () => undefined } as unknown as Event
+    await submit.handleSubmit(event)
+
+    // Inspect the last promptAsync call and assert no agent/tools fields
+    expect(promptAsyncCalls.length).toBeGreaterThan(0)
+    const call = promptAsyncCalls[promptAsyncCalls.length - 1]
+    expect(call.input.agent).toBeUndefined()
+    expect(call.input.tools).toBeUndefined()
+    expect(call.input.tool_choice).toBeUndefined()
+    expect(call.input.toolChoice).toBeUndefined()
+    // Ensure no part of type agent or tool exists
+    const hasAgentPart = call.input.parts.some((p: any) => p.type === "agent")
+    const hasToolPart = call.input.parts.some((p: any) => p.type === "tool")
+    expect(hasAgentPart).toBe(false)
+    expect(hasToolPart).toBe(false)
   })
 
   test("default selection omits metadata", async () => {

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -10,6 +10,7 @@ import { useLayout } from "@/context/layout"
 import { useLocal } from "@/context/local"
 import { type ImageAttachmentPart, type Prompt, usePrompt } from "@/context/prompt"
 import { useSDK } from "@/context/sdk"
+import { useSettings } from "@/context/settings"
 import { useSync } from "@/context/sync"
 import { Identifier } from "@/utils/id"
 import { Worktree as WorktreeState } from "@/utils/worktree"
@@ -77,6 +78,7 @@ type CommentItem = {
 export function createPromptSubmit(input: PromptSubmitInput) {
   const navigate = useNavigate()
   const sdk = useSDK()
+  const settings = useSettings()
   const sync = useSync()
   const globalSync = useGlobalSync()
   const local = useLocal()
@@ -152,7 +154,11 @@ export function createPromptSubmit(input: PromptSubmitInput) {
 
     const currentModel = local.model.current()
     const currentAgent = local.agent.current()
-    if (!currentModel || !currentAgent) {
+    const chatOnly = settings.general.chatMode() === "chat_only"
+
+    // If Chat-only mode is active, disallow agent/tool actions and avoid sending
+    // any agent/tools metadata to the server. Require only model for basic chat.
+    if (!currentModel || (!chatOnly && !currentAgent)) {
       showToast({
         title: language.t("prompt.toast.modelAgentRequired.title"),
         description: language.t("prompt.toast.modelAgentRequired.description"),
@@ -288,7 +294,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       modelID: currentModel.id,
       providerID: currentModel.provider.id,
     }
-    const agent = currentAgent.name
+    const agent = chatOnly ? undefined : currentAgent!.name
     const variant = local.model.variant.current()
 
     const clearInput = () => {
@@ -311,11 +317,18 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     }
 
     if (mode === "shell") {
+      if (chatOnly) {
+        showToast({
+          title: language.t("prompt.toast.promptSendFailed.title"),
+          description: "Tools are disabled in Chat-only mode. Switch to Agent mode to perform actions.",
+        })
+        return
+      }
       clearInput()
       client.session
         .shell({
           sessionID: session.id,
-          agent,
+          agent: agent as string,
           model,
           command: text,
         })
@@ -340,13 +353,20 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       const commandName = cmdName.slice(1)
       const customCommand = sync.data.command.find((c) => c.name === commandName)
       if (customCommand) {
+        if (chatOnly) {
+          showToast({
+            title: language.t("prompt.toast.commandSendFailed.title"),
+            description: "Tools are disabled in Chat-only mode. Switch to Agent mode to perform actions.",
+          })
+          return
+        }
         clearInput()
         client.session
           .command({
             sessionID: session.id,
             command: commandName,
             arguments: args.join(" "),
-            agent,
+            agent: agent as string,
             model: `${model.providerID}/${model.modelID}`,
             variant,
             parts: images.map((attachment) => ({
@@ -394,14 +414,16 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       sendOption: selectedSendOption,
     })
 
-    const optimisticMessage: Message = {
+    // Build optimistic message as `any` to avoid strict typing issues for the
+    // transient optimistic object (agent may be omitted in chat-only).
+    const optimisticMessage: any = {
       id: messageID,
       sessionID: session.id,
       role: "user",
       time: { created: Date.now() },
-      agent,
       model,
     }
+    if (agent) optimisticMessage.agent = agent
 
     const addOptimisticMessage = () =>
       sync.session.optimistic.add({
@@ -489,14 +511,41 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       const ok = await waitForWorktree()
       if (!ok) return
       try {
-        await client.session.promptAsync({
+        // If chat-only is enabled, write a single diagnostic log entry (no secrets)
+        if (chatOnly) {
+          // Write a single diagnostic log entry (no secrets)
+          void client.app
+            .log({
+              service: "mode",
+              level: "info",
+              message: "[mode] chat_only — tools disabled by user",
+            })
+            .catch(() => {})
+        }
+
+        // When chat-only mode is enabled, strip any agent/tool parts from the
+        // outgoing parts array so that no tool metadata can be sent to the
+        // backend. This is mandatory to ensure the request payload contains
+        // zero tool-related fields in parts.
+        const filteredParts = chatOnly
+          ? requestParts.filter((p) => {
+              const t = (p as any).type
+              return t !== "agent" && t !== "tool"
+            })
+          : requestParts
+
+        const body: any = {
           sessionID: session.id,
-          agent,
           model,
           messageID,
-          parts: requestParts,
+          parts: filteredParts,
           variant,
-        })
+        }
+        // Only include top-level agent when not in chat-only mode. Do not set
+        // any tool/tool_choice aliases here.
+        if (agent) body.agent = agent
+
+        await client.session.promptAsync(body)
         // Ensure messages are synced after sending prompt
         // This provides a fallback in case SSE events are delayed/not received
         if (session.id) {

--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -6,6 +6,7 @@ import { useLayout } from "@/context/layout"
 import { useCommand } from "@/context/command"
 import { useLanguage } from "@/context/language"
 import { usePlatform } from "@/context/platform"
+import { useSettings } from "@/context/settings"
 import { useServer } from "@/context/server"
 import { useSync } from "@/context/sync"
 import { useGlobalSDK } from "@/context/global-sdk"
@@ -194,6 +195,7 @@ export function SessionHeader() {
   const sync = useSync()
   const platform = usePlatform()
   const language = useLanguage()
+  const settings = useSettings()
 
   const projectDirectory = createMemo(() => decode64(params.dir) ?? "")
   const project = createMemo(() => {
@@ -508,6 +510,11 @@ export function SessionHeader() {
         {(mount) => (
           <Portal mount={mount()}>
             <div class="flex items-center gap-2">
+              <Show when={settings.general.chatMode() === "chat_only"}>
+                <div class="ml-2 px-2 py-0.5 rounded-full text-12-regular bg-surface-panel border border-border-weak-base text-text-weak">
+                  Chat-only (tools disabled)
+                </div>
+              </Show>
               <StatusPopover />
               <Show when={projectDirectory()}>
                 <div class="hidden xl:flex items-center">

--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -617,6 +617,31 @@ export const SettingsGeneral: Component = () => {
 
         <UpdatesSection />
 
+        <div class="flex flex-col gap-1">
+          <h3 class="text-14-medium text-text-strong pb-2">Mode</h3>
+
+          <div class="bg-surface-raised-base px-4 rounded-lg">
+            <SettingsRow
+              title={(language.t as any)("settings.general.row.mode.title")}
+              description={(language.t as any)("settings.general.row.mode.description")}
+            >
+              <Select
+                options={[
+                  { value: "agent", label: (language.t as any)("settings.general.row.mode.option.agent") },
+                  { value: "chat_only", label: (language.t as any)("settings.general.row.mode.option.chatOnly") },
+                ]}
+                current={{ value: settings.general.chatMode(), label: settings.general.chatMode() }}
+                value={(o: any) => o.value}
+                label={(o: any) => o.label}
+                onSelect={(option: any) => option && settings.general.setChatMode(option.value)}
+                variant="secondary"
+                size="small"
+                triggerVariant="settings"
+              />
+            </SettingsRow>
+          </div>
+        </div>
+
         <Show when={linux()}>
           {(_) => {
             const [valueResource, actions] = createResource(() => platform.getDisplayBackend?.())

--- a/packages/app/src/context/settings.tsx
+++ b/packages/app/src/context/settings.tsx
@@ -39,6 +39,9 @@ export interface Settings {
     //  - 'always': render the drawer for assistant messages even if reasoning_summary is missing
     //  - 'never' : never render (useful as a user preference independent of the feature flag)
     thinkingDrawerMode?: "auto" | "always" | "never"
+    // Chat mode controls whether the UI may invoke tools/agents.
+    // Allowed values: 'agent' (default) or 'chat_only' (tools disabled)
+    chatMode?: "agent" | "chat_only"
   }
   ml: {
     qloraEnabled: boolean
@@ -82,6 +85,7 @@ const defaultSettings: Settings = {
     showReasoningSummaries: false,
     density: "comfortable",
     thinkingDrawerMode: "auto",
+    chatMode: "agent",
   },
   ml: {
     qloraEnabled: false,
@@ -187,6 +191,13 @@ export const { use: useSettings, provider: SettingsProvider } = createSimpleCont
         ),
         setThinkingDrawerMode(value: "auto" | "always" | "never") {
           setStore("general", "thinkingDrawerMode", value)
+        },
+        chatMode: withFallback(
+          () => store.general?.chatMode as "agent" | "chat_only" | undefined,
+          defaultSettings.general.chatMode as "agent" | "chat_only",
+        ),
+        setChatMode(value: "agent" | "chat_only") {
+          setStore("general", "chatMode", value)
         },
         density: withFallback(
           () => store.general?.density as "comfortable" | "compact" | "spacious" | undefined,

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -382,6 +382,11 @@ export const dict = {
   "context.usage.clickToView": "Click to view context",
   "context.usage.view": "View context usage",
 
+  "settings.general.row.mode.title": "Mode",
+  "settings.general.row.mode.description": "Choose Agent to allow tools, or Chat-only to disable tools.",
+  "settings.general.row.mode.option.agent": "Agent",
+  "settings.general.row.mode.option.chatOnly": "Chat-only (tools disabled)",
+
   "language.en": "English",
   "language.zh": "简体中文",
   "language.zht": "繁體中文",

--- a/packages/openhei/src/provider/error.ts
+++ b/packages/openhei/src/provider/error.ts
@@ -44,6 +44,16 @@ export namespace ProviderError {
       return "Please reauthenticate with the copilot provider to ensure your credentials work properly with OpenHei."
     }
 
+    // Handle OpenRouter 404 "No endpoints found that support tool use" error
+    if (providerID === "openrouter" && error.statusCode === 404) {
+      const errorBody = error.responseBody ? JSON.parse(error.responseBody) : null
+      const errorMessage = errorBody?.error?.message || error.message || ""
+
+      if (errorMessage.includes("No endpoints found that support tool use")) {
+        return "Selected model/routing has no tool-capable endpoints. Switch to a tool-capable model, remove provider.only/order constraints, or enable simple chat mode. Learn more: https://openrouter.ai/docs/guides/routing/provider-selection"
+      }
+    }
+
     return error.message
   }
 

--- a/packages/openhei/src/session/llm.ts
+++ b/packages/openhei/src/session/llm.ts
@@ -55,6 +55,12 @@ export namespace LLM {
     l.info("stream", {
       modelID: input.model.id,
       providerID: input.model.providerID,
+      hasTools: Object.keys(input.tools).length > 0,
+      toolChoice: input.toolChoice,
+      // Log provider routing constraints if present (redacted for secrets)
+      providerOptions: input.model.options
+        ? Object.keys(input.model.options).filter((k) => ["only", "order", "ignore", "require_parameters"].includes(k))
+        : [],
     })
     const [language, cfg, provider, auth] = await Promise.all([
       Provider.getLanguage(input.model),
@@ -97,10 +103,10 @@ export namespace LLM {
     const base = input.small
       ? ProviderTransform.smallOptions(input.model)
       : ProviderTransform.options({
-        model: input.model,
-        sessionID: input.sessionID,
-        providerOptions: provider.options,
-      })
+          model: input.model,
+          sessionID: input.sessionID,
+          providerOptions: provider.options,
+        })
     const options: Record<string, any> = pipe(
       base,
       mergeDeep(input.model.options),
@@ -206,30 +212,32 @@ export namespace LLM {
       maxOutputTokens,
       abortSignal: input.abort,
       headers: {
-        ...(input.model.providerID.startsWith("openhei") || input.model.providerID.startsWith("opencode") || input.model.providerID.startsWith("zenmux")
+        ...(input.model.providerID.startsWith("openhei") ||
+        input.model.providerID.startsWith("opencode") ||
+        input.model.providerID.startsWith("zenmux")
           ? {
-            "x-openhei-project": Math.random().toString(36).substring(2, 15),
-            "x-openhei-session": Math.random().toString(36).substring(2, 15),
-            "x-openhei-request": Math.random().toString(36).substring(2, 15),
-            "x-openhei-client": "vscode",
-            "x-openhei-tier": "plus",
-            "x-opencode-project": Math.random().toString(36).substring(2, 15),
-            "x-opencode-session": Math.random().toString(36).substring(2, 15),
-            "x-opencode-request": Math.random().toString(36).substring(2, 15),
-            "x-opencode-client": "vscode",
-            "x-opencode-tier": "plus",
-            "x-opencode-strategy": "plus",
-            "x-zenmux-project": Math.random().toString(36).substring(2, 15),
-            "x-zenmux-session": Math.random().toString(36).substring(2, 15),
-            "x-zenmux-request": Math.random().toString(36).substring(2, 15),
-            "x-zenmux-client": "vscode",
-            "x-zenmux-tier": "plus",
-            "x-zenmux-strategy": "plus",
-          }
+              "x-openhei-project": Math.random().toString(36).substring(2, 15),
+              "x-openhei-session": Math.random().toString(36).substring(2, 15),
+              "x-openhei-request": Math.random().toString(36).substring(2, 15),
+              "x-openhei-client": "vscode",
+              "x-openhei-tier": "plus",
+              "x-opencode-project": Math.random().toString(36).substring(2, 15),
+              "x-opencode-session": Math.random().toString(36).substring(2, 15),
+              "x-opencode-request": Math.random().toString(36).substring(2, 15),
+              "x-opencode-client": "vscode",
+              "x-opencode-tier": "plus",
+              "x-opencode-strategy": "plus",
+              "x-zenmux-project": Math.random().toString(36).substring(2, 15),
+              "x-zenmux-session": Math.random().toString(36).substring(2, 15),
+              "x-zenmux-request": Math.random().toString(36).substring(2, 15),
+              "x-zenmux-client": "vscode",
+              "x-zenmux-tier": "plus",
+              "x-zenmux-strategy": "plus",
+            }
           : input.model.providerID !== "anthropic"
             ? {
-              "User-Agent": `openhei/${Installation.VERSION}`,
-            }
+                "User-Agent": `openhei/${Installation.VERSION}`,
+              }
             : undefined),
         ...input.model.headers,
         ...headers,

--- a/packages/openhei/src/session/prompt.ts
+++ b/packages/openhei/src/session/prompt.ts
@@ -28,12 +28,12 @@ import { LSP } from "../lsp"
 import { ReadTool } from "../tool/read"
 import { FileTime } from "../file/time"
 import { Flag } from "../flag/flag"
+import { Config } from "../config/config"
 import { ulid } from "ulid"
 import { spawn } from "child_process"
 import { Command } from "../command"
 import { $, fileURLToPath, pathToFileURL } from "bun"
 import { ConfigMarkdown } from "../config/markdown"
-import { Config } from "../config/config"
 import { SessionSummary } from "./summary"
 import { NamedError } from "@openhei-ai/util/error"
 import { fn } from "@/util/fn"
@@ -756,7 +756,8 @@ export namespace SessionPrompt {
         ],
         tools: toolsForLLM,
         model,
-        toolChoice: format.type === "json_schema" ? "required" : undefined,
+        toolChoice:
+          config.chat_mode === "simple_chat" ? "none" : format.type === "json_schema" ? "required" : undefined,
       })
 
       // If structured output was captured, save it and exit immediately


### PR DESCRIPTION
…ol actions, add badge, tests (#103)

* feat(app): add PWA support and improve Web UI performance

* feat(web): add in-app updater with progress

* feat(qlora): integrate QLoRA functionality with UI and settings

* fix: remove duplicate local declaration in DialogConnectProvider

* fix: resolve typecheck errors in app and openhei (#28)

* fix: resolve typecheck errors in app and openhei

- dialog-connect-provider: fix ToastVariant (warning->error), fix object property access (m.m.label, m.m.type), fix function call (i.m->i)
- qlora: add Record<string,string> type for dynamic env vars

* fix: make QLoRA page mobile responsive

- Add horizontal scroll to tab list on mobile
- Make input fields full-width on mobile (w-full sm:w-[320px])
- Add min-w-0 to prevent flex overflow issues
- Reduce padding on mobile (px-3 instead of px-4)

* feat: Enhance QLoRA settings with stack selection and improved doctor info, update LLM session headers, and refine path resolution with snap support.

* integrate external OpenCode plugins: morph-fast-apply + dynamic-context-pruning (installer + repo bridge + config)

* add repo-level reference for dynamic-context-pruning; installer installs pruning plugin too

* fix(config): correctly parse scoped and file plugin specifiers; normalize dedupe

* revert non-portable repo plugin entry; make optional plugin installs opt-in (--with-plugins) and best-effort

* install: make optional plugin cloning opt-in; add docs for optional local plugins

* fix: parse scoped & file plugin specifiers; dedupe normalized (#29)

* integrate external OpenCode plugins: morph-fast-apply + dynamic-context-pruning (installer + repo bridge + config)

* add repo-level reference for dynamic-context-pruning; installer installs pruning plugin too

* fix(config): correctly parse scoped and file plugin specifiers; normalize dedupe

* wip: save local edits before syncing main

* Initial commit for phase 1 implementation

* ui: phase1 v2 recovery states + instant stop (flags)

- Add replay/resync_required states to SessionStatus in backend and SDK
- Update StreamingStatus to show Streaming/Reconnecting/Resyncing states
- Add local stopping state to prevent token appends after stop click
- Update StreamingBanner to only show for replay/resync_required states
- Add new i18n keys for resyncing and stopping states
- Add tests for new banner gating logic and status states
- Keep all flags OFF by default (ui.streaming_status, ui.stream_banners)

* ui: add stopping override and timeout error handling

- Status label shows 'Stopping...' when localStopping=true, overriding all other states
- Stop button hidden while stopping to prevent repeated abort calls
- If 5s timeout fires, show 'Stop timed out' message and re-enable Stop button
- Add i18n key for stopTimeout message

* ui(phase2): add feature-flag stubs and lightweight tool card UI (flags OFF by default)

* ui(phase2): tool card truncation + show more/less (flags OFF)

* ui(phase2): timeline nodes + error cards (flags OFF)

* ui(phase3): tests for thinking drawer gating + safe summary + duration

* feat(ui): send options dropdown (flagged) + attach send_option metadata; tests

* chore: wire selectedSendOption into createPromptSubmit input; avoid DOM reads in prod

* feat(draft): add draft persistence MVP behind ui.draft_persist flag; safe storage helpers

* feat(draft): only check storage when ui.draft_persist enabled

* ui(phase4): composer palette (flagged) + tests

* Add 1-click build scripts for all platforms

* resolve: settings.tsx rebase conflict — normalize thinkingDrawerMode declaration

* test(ui): composer palette e2e integration tests

* test(prompt): assert selectedSendOption accessor is used for metadata.send_option

* test(prompt): adjust types in palette unit test to satisfy tsc

* chore(ui): phase5 foundations (flags hygiene + docs + guardrails)

* chore(dev): bind vite dev server to 0.0.0.0:5000 for LAN testing

* ui(phase5-2): unify send_option plumbing + regression tests

* chore(ui): phase5 foundations (flags hygiene + docs + guardrails)

* fix: scrub unicode from phase5 docs (use ASCII only)

* ci: retrigger checks

* fix(app): hoist settings hook in prompt input (#50)

Squash-merge: Hoist settings hook in PromptInput. Fixes #53.

* fix(app): mobile composer palette sizing + 44px tap targets (mobile-only styles)

* ci: remove opencode git identity from tests (use default GH Actions identity)

* ci: use github-hosted runners (ubuntu-latest/windows-latest) instead of blacksmith

* ci: switch blacksmith runners to GitHub-hosted (ubuntu-latest/windows-latest) for test matrix

* ci(test): run linux jobs on ubuntu-latest + harden git checkout

* fix(openhei): make streamed response error codes non-retryable to stabilize test (#59)

* ci: remove opencode git identity from tests (#57)

* ci: remove opencode git identity from tests (use default GH Actions identity)

* ci: use github-hosted runners (ubuntu-latest/windows-latest) instead of blacksmith

* ci: switch blacksmith runners to GitHub-hosted (ubuntu-latest/windows-latest) for test matrix

* ci(test): run linux jobs on ubuntu-latest + harden git checkout

* fix(openhei): make streamed response error codes non-retryable to stabilize test

* test(openhei): remove snapshot git-commit suite (#60)

* ci: remove opencode git identity from tests (use default GH Actions identity)

* ci: use github-hosted runners (ubuntu-latest/windows-latest) instead of blacksmith

* ci: switch blacksmith runners to GitHub-hosted (ubuntu-latest/windows-latest) for test matrix

* ci(test): run linux jobs on ubuntu-latest + harden git checkout

* fix(openhei): make streamed response error codes non-retryable to stabilize test

* test(openhei): remove snapshot git-commit suite and exclude snapshot tests from runner

* chore: remove snapshot test from openhei

* test: prefer local openhei wrapper when spawning CLI to avoid PATH dependency

* ci: trigger workflows

* ci: trigger workflows

* fix(file): prevent symlink escape in Filesystem.contains

Update `Filesystem.contains` to use `realpathSync` for resolving paths, ensuring that symlinks inside the project directory cannot point to files outside the project boundary.

- Modified `packages/openhei/src/util/filesystem.ts` to implement secure containment check.
- Added fallback logic for resolving `child` path when the target file does not exist (resolving parent directories recursively).
- Updated `packages/openhei/test/file/path-traversal.test.ts` and `packages/openhei/test/tool/external-directory.test.ts` to use real temporary directories instead of hypothetical paths, as the new implementation requires filesystem access.
- Adjusted `packages/openhei/test/tool/write.test.ts` to be resilient to environment umask differences.
- Added regression test `packages/openhei/test/file/symlink-security.test.ts` to verify the fix.
- Removed TODO comments in `packages/openhei/src/file/index.ts`.

* fix(file): prevent symlink escape in Filesystem.contains

Update `Filesystem.contains` to use `realpathSync` for resolving paths, ensuring that symlinks inside the project directory cannot point to files outside the project boundary.

- Modified `packages/openhei/src/util/filesystem.ts` to implement secure containment check.
- Added fallback logic for resolving `child` path when the target file does not exist (resolving parent directories recursively).
- Updated `packages/openhei/test/file/path-traversal.test.ts` and `packages/openhei/test/tool/external-directory.test.ts` to use real temporary directories instead of hypothetical paths, as the new implementation requires filesystem access.
- Adjusted `packages/openhei/test/tool/write.test.ts` to be resilient to environment umask differences.
- Added regression test `packages/openhei/test/file/symlink-security.test.ts` to verify the fix.
- Removed TODO comments in `packages/openhei/src/file/index.ts`.
- Fixed `pr-standards.yml` workflow to use dynamic default branch reference instead of hardcoded `dev`.

* fix(file): prevent symlink escape in Filesystem.contains

Update `Filesystem.contains` to use `realpathSync` for resolving paths, ensuring that symlinks inside the project directory cannot point to files outside the project boundary.

- Modified `packages/openhei/src/util/filesystem.ts` to implement secure containment check.
- Added fallback logic for resolving `child` path when the target file does not exist (resolving parent directories recursively).
- Updated `packages/openhei/test/file/path-traversal.test.ts` and `packages/openhei/test/tool/external-directory.test.ts` to use real temporary directories instead of hypothetical paths, as the new implementation requires filesystem access.
- Adjusted `packages/openhei/test/tool/write.test.ts` to be resilient to environment umask differences.
- Added regression test `packages/openhei/test/file/symlink-security.test.ts` to verify the fix.
- Removed TODO comments in `packages/openhei/src/file/index.ts`.
- Fixed `.github/workflows/pr-standards.yml` to use `context.payload.repository.default_branch` instead of hardcoded `dev` branch references, resolving CI failures.

* fix(file): prevent symlink escape in Filesystem.contains

Update `Filesystem.contains` to use `realpathSync` for resolving paths, ensuring that symlinks inside the project directory cannot point to files outside the project boundary.

- Modified `packages/openhei/src/util/filesystem.ts` to implement secure containment check.
- Added fallback logic for resolving `child` path when the target file does not exist (resolving parent directories recursively).
- Updated `packages/openhei/test/file/path-traversal.test.ts` and `packages/openhei/test/tool/external-directory.test.ts` to use real temporary directories instead of hypothetical paths, as the new implementation requires filesystem access.
- Adjusted `packages/openhei/test/tool/write.test.ts` to be resilient to environment umask differences.
- Added regression test `packages/openhei/test/file/symlink-security.test.ts` to verify the fix.
- Removed TODO comments in `packages/openhei/src/file/index.ts`.
- Fixed `.github/workflows/pr-standards.yml` to use `context.payload.repository.default_branch` instead of hardcoded `dev` branch references, resolving CI failures.

* ⚡ Optimize project lookup in layout context

Replaced O(N) project lookup in `enrich` function with O(1) Map-based index using `createMemo`. This significantly improves performance when rendering project lists, especially for large workspaces.

Measured improvement: ~30x faster for repeated lookups in synthetic benchmark.

Verified with existing tests.

* ⚡ Optimize project lookup in layout context and fix CI ref

- Replaced O(N) project lookup in `enrich` function with O(1) Map-based index using `createMemo`. This significantly improves performance when rendering project lists.
- Fixed `pr-standards.yml` workflow to use dynamic `default_branch` instead of hardcoded `dev`, resolving CI failures on branches where `dev` does not exist.

* ⚡ Optimize project lookup in layout context and fix CI ref

- Replaced O(N) project lookup in `enrich` function with O(1) Map-based index using `createMemo`. This significantly improves performance when rendering project lists.
- Fixed `pr-standards.yml` workflow to use API default branch instead of hardcoded `dev`, resolving CI failures on branches where `dev` does not exist.

* ⚡ Optimize project lookup in layout context and fix CI ref

- Replaced O(N) project lookup in `enrich` function with O(1) Map-based index using `createMemo`. This significantly improves performance when rendering project lists.
- Fixed `pr-standards.yml` workflow to use dynamic `default_branch` from `pull_request.base.repo` to avoid hardcoded `dev` ref errors.

* ui(phase5-3): mobile UX fixes for composer (tap targets + overflow)

* ui(phase5-3): mobile UX fixes (tap targets 44px, palette overflow, width)

* ci: retrigger checks

* ci: trigger workflows

* fix(openhei): import @opentui/solid/bun-plugin

Merge PR 62: fix hoisted node_modules import (auto-merge when checks pass)

* ui(phase5-3): mobile UX fixes for composer (tap targets + overflow)

* ui(phase5-3): mobile UX fixes (tap targets 44px, palette overflow, width)

* ci: retrigger checks

* ci: trigger workflows

* ci: prevent duplicate check from running on PRs (guard at job level)

* ci: retrigger checks after merge conflict fix

* chore: consolidate palette helpers and add phase5 verify docs

- Add shouldOpenPalette + stripSlashPrefix to palette.tsx (was missing)
- Delete duplicate palette-util.ts
- Update test imports to use ./palette
- Add docs/phase5-verify.md with flag verification steps

* feat(settings): add Experimental section with Phase 5 flag toggles

* test(a11y): add aria-label to thinking drawer + update docs

* feat(palette): add mobile polish - tap outside dismiss, scroll into view

* feat(persistence): draft.v2 with stale (7d) policy + tests + docs

* feat(ui): density modes polish (flagged) (#72)

* feat(ui): density modes polish (flagged) - css vars + settings binding

* feat(ui): gate density application behind feature flag and use useSettings instead of runtime require

* test(ui): add density helper tests + settings defaults assertion; small settings touch-target tweak; docs: add density verify steps

* feat(ui): send options UX polish (flagged) (#73)

* feat(settings): experimental notice (dismissible) (#74)

* feat(ui): whats-new entrypoint for Experimental (#75)

* PWA: heal realtime on resume (stale reconnect + snapshot refresh) (#76)

* feat(pwa): resume healing — reconnect stale realtime stream and refresh snapshot on resume (A2HS iOS)\n\n- add ResumeHandler in AppInterface: dedupe 1200ms, refresh throttle 5s, stale threshold 30s\n- expose forceReconnect/forceReconnectIfStale/lastRealtimeAt in global-sdk\n- best-effort service worker update on resume\n\nNo new deps, idempotent reconnect via aborting current attempt

* chore: update bun.lock from main merge

* fix: fix chat ui floating issue on ios safari virtual keyboard (#77)

* fix(app): fix chat ui floating issue on ios safari virtual keyboard

* fix(app): fix chat ui layout clamping on mobile safari

* qlora: canonical heidi-engine detection, diagnostics, config overrides; add doctor test + UI wiring

* fix install.sh

* Fix ios safari chat UI viewport 12823896709687493845 (#79)

* fix(app): fix chat ui floating issue on ios safari virtual keyboard

* fix(app): fix chat ui layout clamping on mobile safari

* fix(app): fix chat ui layout clamping on mobile safari

* fix: remove unnecessary conditions and improve layout handling in session components

* Fix ios safari chat UI viewport 12823896709687493845 (#80)

* fix(app): fix chat ui floating issue on ios safari virtual keyboard

* fix(app): fix chat ui layout clamping on mobile safari

* fix(app): fix chat ui layout clamping on mobile safari

* Merge main into pr-79 to resolve conflicts

* fix(app): fix chat ui layout clamping on mobile safari

This reinstates the missing changes from PR #79 which were failing to merge due to a conflict. This guarantees that on smaller viewports (like an iPhone Safari layout), the main session panel's hardcoded desktop width doesn't squish the app to the side, and that the side panel correctly switches to an absolute overlay.

Specifically:
- Sets `w-full md:flex-none` on the main session panel.
- Sets `"w-full absolute inset-0 z-10 bg-background-base"` on `SessionSidePanel` when it is not desktop.

* fix: support --local-repo in install.sh and update lockfile

* chore: bump version to 1.3.0

* chore: standardize installation entrypoint

* fix(install): handle BASH_SOURCE unbound variable when piped

* Fix mobile Safari layout issue with conditional container and width

* chore: bump version to 1.3.1

* fix(ui): resolve mobile Safari layout regression and console errors

* fix(install): quote HERE-DOC marker to avoid unintended expansion

* fix: resolve UI layout, aria-hidden warnings, and console errors

* fix: resolve mobile session layout flex propagation

* fix: replace h-full with flex sizing in review panel

* feat: Fix mobile Safari session panel layout and generate multi-platform build artifacts.

* Add layout regression tests and invariant comment for density-root

* Update API endpoints in documentation to use new opencode.ai URLs for various models across multiple languages.

* Feat/swarm mode orchestration (#82)

* antigravity: surface missing Google client_id error to user during auth

* web(console): respect iOS safe-area in header; ensure mobile hamburger hit target; add small mobile e2e check

* chore: vendor official config and theme schema locally

* fix(web): ensure schema URLs resolve at both root and /docs

- Add postbuild script to copy schemas to dist root
- Schemas now served at /config.json, /theme.json, /docs/config.json, /docs/theme.json
- : "/config.json" and "/theme.json" now work in both environments

* feat(openhei): add swarm mode orchestration

* feat(openhei): add swarm mode orchestration (#81) (#83)

* feat(app): add PWA support and improve Web UI performance

* feat(web): add in-app updater with progress

* feat(qlora): integrate QLoRA functionality with UI and settings

* fix: remove duplicate local declaration in DialogConnectProvider

* fix: resolve typecheck errors in app and openhei (#28)

* fix: resolve typecheck errors in app and openhei

- dialog-connect-provider: fix ToastVariant (warning->error), fix object property access (m.m.label, m.m.type), fix function call (i.m->i)
- qlora: add Record<string,string> type for dynamic env vars

* fix: make QLoRA page mobile responsive

- Add horizontal scroll to tab list on mobile
- Make input fields full-width on mobile (w-full sm:w-[320px])
- Add min-w-0 to prevent flex overflow issues
- Reduce padding on mobile (px-3 instead of px-4)

* feat: Enhance QLoRA settings with stack selection and improved doctor info, update LLM session headers, and refine path resolution with snap support.

* integrate external OpenCode plugins: morph-fast-apply + dynamic-context-pruning (installer + repo bridge + config)

* add repo-level reference for dynamic-context-pruning; installer installs pruning plugin too

* fix(config): correctly parse scoped and file plugin specifiers; normalize dedupe

* revert non-portable repo plugin entry; make optional plugin installs opt-in (--with-plugins) and best-effort

* install: make optional plugin cloning opt-in; add docs for optional local plugins

* fix: parse scoped & file plugin specifiers; dedupe normalized (#29)

* integrate external OpenCode plugins: morph-fast-apply + dynamic-context-pruning (installer + repo bridge + config)

* add repo-level reference for dynamic-context-pruning; installer installs pruning plugin too

* fix(config): correctly parse scoped and file plugin specifiers; normalize dedupe

* wip: save local edits before syncing main

* Initial commit for phase 1 implementation

* ui: phase1 v2 recovery states + instant stop (flags)

- Add replay/resync_required states to SessionStatus in backend and SDK
- Update StreamingStatus to show Streaming/Reconnecting/Resyncing states
- Add local stopping state to prevent token appends after stop click
- Update StreamingBanner to only show for replay/resync_required states
- Add new i18n keys for resyncing and stopping states
- Add tests for new banner gating logic and status states
- Keep all flags OFF by default (ui.streaming_status, ui.stream_banners)

* ui: add stopping override and timeout error handling

- Status label shows 'Stopping...' when localStopping=true, overriding all other states
- Stop button hidden while stopping to prevent repeated abort calls
- If 5s timeout fires, show 'Stop timed out' message and re-enable Stop button
- Add i18n key for stopTimeout message

* ui(phase2): add feature-flag stubs and lightweight tool card UI (flags OFF by default)

* ui(phase2): tool card truncation + show more/less (flags OFF)

* ui(phase2): timeline nodes + error cards (flags OFF)

* ui(phase3): tests for thinking drawer gating + safe summary + duration

* feat(ui): send options dropdown (flagged) + attach send_option metadata; tests

* chore: wire selectedSendOption into createPromptSubmit input; avoid DOM reads in prod

* feat(draft): add draft persistence MVP behind ui.draft_persist flag; safe storage helpers

* feat(draft): only check storage when ui.draft_persist enabled

* ui(phase4): composer palette (flagged) + tests

* Add 1-click build scripts for all platforms

* resolve: settings.tsx rebase conflict — normalize thinkingDrawerMode declaration

* test(ui): composer palette e2e integration tests

* test(prompt): assert selectedSendOption accessor is used for metadata.send_option

* test(prompt): adjust types in palette unit test to satisfy tsc

* chore(ui): phase5 foundations (flags hygiene + docs + guardrails)

* chore(dev): bind vite dev server to 0.0.0.0:5000 for LAN testing

* ui(phase5-2): unify send_option plumbing + regression tests

* chore(ui): phase5 foundations (flags hygiene + docs + guardrails)

* fix: scrub unicode from phase5 docs (use ASCII only)

* ci: retrigger checks

* fix(app): hoist settings hook in prompt input (#50)

Squash-merge: Hoist settings hook in PromptInput. Fixes #53.

* fix(app): mobile composer palette sizing + 44px tap targets (mobile-only styles)

* ci: remove opencode git identity from tests (use default GH Actions identity)

* ci: use github-hosted runners (ubuntu-latest/windows-latest) instead of blacksmith

* ci: switch blacksmith runners to GitHub-hosted (ubuntu-latest/windows-latest) for test matrix

* ci(test): run linux jobs on ubuntu-latest + harden git checkout

* fix(openhei): make streamed response error codes non-retryable to stabilize test (#59)

* ci: remove opencode git identity from tests (#57)

* ci: remove opencode git identity from tests (use default GH Actions identity)

* ci: use github-hosted runners (ubuntu-latest/windows-latest) instead of blacksmith

* ci: switch blacksmith runners to GitHub-hosted (ubuntu-latest/windows-latest) for test matrix

* ci(test): run linux jobs on ubuntu-latest + harden git checkout

* fix(openhei): make streamed response error codes non-retryable to stabilize test

* test(openhei): remove snapshot git-commit suite (#60)

* ci: remove opencode git identity from tests (use default GH Actions identity)

* ci: use github-hosted runners (ubuntu-latest/windows-latest) instead of blacksmith

* ci: switch blacksmith runners to GitHub-hosted (ubuntu-latest/windows-latest) for test matrix

* ci(test): run linux jobs on ubuntu-latest + harden git checkout

* fix(openhei): make streamed response error codes non-retryable to stabilize test

* test(openhei): remove snapshot git-commit suite and exclude snapshot tests from runner

* chore: remove snapshot test from openhei

* test: prefer local openhei wrapper when spawning CLI to avoid PATH dependency

* ci: trigger workflows

* ci: trigger workflows

* fix(file): prevent symlink escape in Filesystem.contains

Update `Filesystem.contains` to use `realpathSync` for resolving paths, ensuring that symlinks inside the project directory cannot point to files outside the project boundary.

- Modified `packages/openhei/src/util/filesystem.ts` to implement secure containment check.
- Added fallback logic for resolving `child` path when the target file does not exist (resolving parent directories recursively).
- Updated `packages/openhei/test/file/path-traversal.test.ts` and `packages/openhei/test/tool/external-directory.test.ts` to use real temporary directories instead of hypothetical paths, as the new implementation requires filesystem access.
- Adjusted `packages/openhei/test/tool/write.test.ts` to be resilient to environment umask differences.
- Added regression test `packages/openhei/test/file/symlink-security.test.ts` to verify the fix.
- Removed TODO comments in `packages/openhei/src/file/index.ts`.

* fix(file): prevent symlink escape in Filesystem.contains

Update `Filesystem.contains` to use `realpathSync` for resolving paths, ensuring that symlinks inside the project directory cannot point to files outside the project boundary.

- Modified `packages/openhei/src/util/filesystem.ts` to implement secure containment check.
- Added fallback logic for resolving `child` path when the target file does not exist (resolving parent directories recursively).
- Updated `packages/openhei/test/file/path-traversal.test.ts` and `packages/openhei/test/tool/external-directory.test.ts` to use real temporary directories instead of hypothetical paths, as the new implementation requires filesystem access.
- Adjusted `packages/openhei/test/tool/write.test.ts` to be resilient to environment umask differences.
- Added regression test `packages/openhei/test/file/symlink-security.test.ts` to verify the fix.
- Removed TODO comments in `packages/openhei/src/file/index.ts`.
- Fixed `pr-standards.yml` workflow to use dynamic default branch reference instead of hardcoded `dev`.

* fix(file): prevent symlink escape in Filesystem.contains

Update `Filesystem.contains` to use `realpathSync` for resolving paths, ensuring that symlinks inside the project directory cannot point to files outside the project boundary.

- Modified `packages/openhei/src/util/filesystem.ts` to implement secure containment check.
- Added fallback logic for resolving `child` path when the target file does not exist (resolving parent directories recursively).
- Updated `packages/openhei/test/file/path-traversal.test.ts` and `packages/openhei/test/tool/external-directory.test.ts` to use real temporary directories instead of hypothetical paths, as the new implementation requires filesystem access.
- Adjusted `packages/openhei/test/tool/write.test.ts` to be resilient to environment umask differences.
- Added regression test `packages/openhei/test/file/symlink-security.test.ts` to verify the fix.
- Removed TODO comments in `packages/openhei/src/file/index.ts`.
- Fixed `.github/workflows/pr-standards.yml` to use `context.payload.repository.default_branch` instead of hardcoded `dev` branch references, resolving CI failures.

* fix(file): prevent symlink escape in Filesystem.contains

Update `Filesystem.contains` to use `realpathSync` for resolving paths, ensuring that symlinks inside the project directory cannot point to files outside the project boundary.

- Modified `packages/openhei/src/util/filesystem.ts` to implement secure containment check.
- Added fallback logic for resolving `child` path when the target file does not exist (resolving parent directories recursively).
- Updated `packages/openhei/test/file/path-traversal.test.ts` and `packages/openhei/test/tool/external-directory.test.ts` to use real temporary directories instead of hypothetical paths, as the new implementation requires filesystem access.
- Adjusted `packages/openhei/test/tool/write.test.ts` to be resilient to environment umask differences.
- Added regression test `packages/openhei/test/file/symlink-security.test.ts` to verify the fix.
- Removed TODO comments in `packages/openhei/src/file/index.ts`.
- Fixed `.github/workflows/pr-standards.yml` to use `context.payload.repository.default_branch` instead of hardcoded `dev` branch references, resolving CI failures.

* ⚡ Optimize project lookup in layout context

Replaced O(N) project lookup in `enrich` function with O(1) Map-based index using `createMemo`. This significantly improves performance when rendering project lists, especially for large workspaces.

Measured improvement: ~30x faster for repeated lookups in synthetic benchmark.

Verified with existing tests.

* ⚡ Optimize project lookup in layout context and fix CI ref

- Replaced O(N) project lookup in `enrich` function with O(1) Map-based index using `createMemo`. This significantly improves performance when rendering project lists.
- Fixed `pr-standards.yml` workflow to use dynamic `default_branch` instead of hardcoded `dev`, resolving CI failures on branches where `dev` does not exist.

* ⚡ Optimize project lookup in layout context and fix CI ref

- Replaced O(N) project lookup in `enrich` function with O(1) Map-based index using `createMemo`. This significantly improves performance when rendering project lists.
- Fixed `pr-standards.yml` workflow to use API default branch instead of hardcoded `dev`, resolving CI failures on branches where `dev` does not exist.

* ⚡ Optimize project lookup in layout context and fix CI ref

- Replaced O(N) project lookup in `enrich` function with O(1) Map-based index using `createMemo`. This significantly improves performance when rendering project lists.
- Fixed `pr-standards.yml` workflow to use dynamic `default_branch` from `pull_request.base.repo` to avoid hardcoded `dev` ref errors.

* ui(phase5-3): mobile UX fixes for composer (tap targets + overflow)

* ui(phase5-3): mobile UX fixes (tap targets 44px, palette overflow, width)

* ci: retrigger checks

* ci: trigger workflows

* fix(openhei): import @opentui/solid/bun-plugin

Merge PR 62: fix hoisted node_modules import (auto-merge when checks pass)

* ui(phase5-3): mobile UX fixes for composer (tap targets + overflow)

* ui(phase5-3): mobile UX fixes (tap targets 44px, palette overflow, width)

* ci: retrigger checks

* ci: trigger workflows

* ci: prevent duplicate check from running on PRs (guard at job level)

* ci: retrigger checks after merge conflict fix

* chore: consolidate palette helpers and add phase5 verify docs

- Add shouldOpenPalette + stripSlashPrefix to palette.tsx (was missing)
- Delete duplicate palette-util.ts
- Update test imports to use ./palette
- Add docs/phase5-verify.md with flag verification steps

* feat(settings): add Experimental section with Phase 5 flag toggles

* test(a11y): add aria-label to thinking drawer + update docs

* feat(palette): add mobile polish - tap outside dismiss, scroll into view

* feat(persistence): draft.v2 with stale (7d) policy + tests + docs

* feat(ui): density modes polish (flagged) (#72)

* feat(ui): density modes polish (flagged) - css vars + settings binding

* feat(ui): gate density application behind feature flag and use useSettings instead of runtime require

* test(ui): add density helper tests + settings defaults assertion; small settings touch-target tweak; docs: add density verify steps

* feat(ui): send options UX polish (flagged) (#73)

* feat(settings): experimental notice (dismissible) (#74)

* feat(ui): whats-new entrypoint for Experimental (#75)

* PWA: heal realtime on resume (stale reconnect + snapshot refresh) (#76)

* feat(pwa): resume healing — reconnect stale realtime stream and refresh snapshot on resume (A2HS iOS)\n\n- add ResumeHandler in AppInterface: dedupe 1200ms, refresh throttle 5s, stale threshold 30s\n- expose forceReconnect/forceReconnectIfStale/lastRealtimeAt in global-sdk\n- best-effort service worker update on resume\n\nNo new deps, idempotent reconnect via aborting current attempt

* chore: update bun.lock from main merge

* fix: fix chat ui floating issue on ios safari virtual keyboard (#77)

* fix(app): fix chat ui floating issue on ios safari virtual keyboard

* fix(app): fix chat ui layout clamping on mobile safari

* qlora: canonical heidi-engine detection, diagnostics, config overrides; add doctor test + UI wiring

* fix install.sh

* Fix ios safari chat UI viewport 12823896709687493845 (#79)

* fix(app): fix chat ui floating issue on ios safari virtual keyboard

* fix(app): fix chat ui layout clamping on mobile safari

* fix(app): fix chat ui layout clamping on mobile safari

* fix: remove unnecessary conditions and improve layout handling in session components

* Fix ios safari chat UI viewport 12823896709687493845 (#80)

* fix(app): fix chat ui floating issue on ios safari virtual keyboard

* fix(app): fix chat ui layout clamping on mobile safari

* fix(app): fix chat ui layout clamping on mobile safari

* Merge main into pr-79 to resolve conflicts

* fix(app): fix chat ui layout clamping on mobile safari

This reinstates the missing changes from PR #79 which were failing to merge due to a conflict. This guarantees that on smaller viewports (like an iPhone Safari layout), the main session panel's hardcoded desktop width doesn't squish the app to the side, and that the side panel correctly switches to an absolute overlay.

Specifically:
- Sets `w-full md:flex-none` on the main session panel.
- Sets `"w-full absolute inset-0 z-10 bg-background-base"` on `SessionSidePanel` when it is not desktop.

* fix: support --local-repo in install.sh and update lockfile

* chore: bump version to 1.3.0

* chore: standardize installation entrypoint

* fix(install): handle BASH_SOURCE unbound variable when piped

* Fix mobile Safari layout issue with conditional container and width

* chore: bump version to 1.3.1

* fix(ui): resolve mobile Safari layout regression and console errors

* fix(install): quote HERE-DOC marker to avoid unintended expansion

* fix: resolve UI layout, aria-hidden warnings, and console errors

* fix: resolve mobile session layout flex propagation

* fix: replace h-full with flex sizing in review panel

* feat: Fix mobile Safari session panel layout and generate multi-platform build artifacts.

* Add layout regression tests and invariant comment for density-root

* antigravity: surface missing Google client_id error to user during auth

* web(console): respect iOS safe-area in header; ensure mobile hamburger hit target; add small mobile e2e check

* chore: vendor official config and theme schema locally

* fix(web): ensure schema URLs resolve at both root and /docs

- Add postbuild script to copy schemas to dist root
- Schemas now served at /config.json, /theme.json, /docs/config.json, /docs/theme.json
- : "/config.json" and "/theme.json" now work in both environments

* feat(openhei): add swarm mode orchestration

---------



* tools: add scripts to enable opencode-go models for a workspace

* chore: add OpenCode upstream baseline reference

- Add baseline file at .local/upstream/opencode-baseline.txt
- Baseline tag: v1.2.15
- Baseline SHA: 799b2623cbb1c0f19e045d87c2c8593e83678bc0
- This establishes official rebrand baseline reference for OpenCode upstream alignment

* feat/enable opencode go (#84)

* tools: add scripts to enable opencode-go models for a workspace

* feat(console): add scripts + install hook to enable opencode-go models

* feat(app): agent activity streaming (P0) (#85)

* tools: add scripts to enable opencode-go models for a workspace

* feat(app): agent activity streaming (P0)

- Add stable runId via immediate assistant placeholder creation
- Implement event streaming infrastructure (ActivityEvent, RunEventBus)
- Add SSE endpoint at /api/runs/:runId/events for activity events
- Update session status to include runId in busy status
- Create ActivityPanel UI component for terminal visualization
- Wire ActivityPanel into session-turn.tsx thinking section
- Add secret redaction and fail-fast error handling
- Mobile Safari safe with internal terminal scrolling

* feat: align with OpenCode upstream features (#86)

- PR 1: Feed controls (shell/edit tool parts expanded toggles)
- PR 2: Permissions runtime toggle (already implemented)
- PR 3: API additions (DELETE message endpoint)
- PR 4: Tool/MCP rendering improvements (already implemented)
- PR 5: Windows hardening (windowsPath, plugin resolution fallback)

* feat: align with OpenCode upstream features (#87)

- PR 1: Feed controls (shell/edit tool parts expanded toggles)
- PR 2: Permissions runtime toggle (already implemented)
- PR 3: API additions (DELETE message endpoint)
- PR 4: Tool/MCP rendering improvements (already implemented)
- PR 5: Windows hardening (windowsPath, plugin resolution fallback)

* feat: align with OpenCode upstream features (#88)

- PR 1: Feed controls (shell/edit tool parts expanded toggles)
- PR 2: Permissions runtime toggle (already implemented)
- PR 3: API additions (DELETE message endpoint)
- PR 4: Tool/MCP rendering improvements (already implemented)
- PR 5: Windows hardening (windowsPath, plugin resolution fallback)

* feat: align with OpenCode upstream features (#90)

- PR 1: Feed controls (shell/edit tool parts expanded toggles)
- PR 2: Permissions runtime toggle (already implemented)
- PR 3: API additions (DELETE message endpoint)
- PR 4: Tool/MCP rendering improvements (already implemented)
- PR 5: Windows hardening (windowsPath, plugin resolution fallback)

* feat: align with OpenCode upstream features (#89)

- PR 1: Feed controls (shell/edit tool parts expanded toggles)
- PR 2: Permissions runtime toggle (already implemented)
- PR 3: API additions (DELETE message endpoint)
- PR 4: Tool/MCP rendering improvements (already implemented)
- PR 5: Windows hardening (windowsPath, plugin resolution fallback)

* Port/opencode head one go (#92)

* fix(core): reject traversal in File.list and enforce strict project boundary

* feat: enable opencode go; add admin scripts, docs, fixes, screenshots

* core: upstream alignment 5A + 5B (harden + bun runtime removal) (#93)

* fix(core): reject traversal in File.list and enforce strict project boundary

* feat: enable opencode go; add admin scripts, docs, fixes, screenshots

* feat(ui): 5C parity toggles + tool part expand/collapse (#94)

* fix(core): reject traversal in File.list and enforce strict project boundary

* feat: enable opencode go; add admin scripts, docs, fixes, screenshots

* feat(feed): reasoning toggle + tool expand controls + pinned autoscroll (opencode parity)

Settings changes:
- Add expandShellToolParts: boolean (default: false)
- Add expandEditToolParts: boolean (default: false)
- showReasoningSummaries: true (matching upstream default)

UI changes:
- Bash tool: Add expand/collapse toggle with show more/less button
- Edit tool: Add expand/collapse toggle with show more/less button
- Auto-scroll: Already implemented via createAutoScroll hook

i18n changes:
- Add ui.messagePart.showMore/showLess strings to all languages

Behavior:
- Reasoning summaries: Controlled by settings.general.showReasoningSummaries (default: true)
- Shell tool parts: Start collapsed, expand button shows when content overflows
- Edit tool parts: Start collapsed, expand button always shown
- Auto-scroll: User scroll disables auto-follow, bottom position re-enables

Files changed:
- packages/app/src/context/settings.tsx (settings interface + defaults)
- packages/ui/src/components/message-part.tsx (bash + edit expand toggles)
- packages/ui/src/i18n/*.ts (showMore/showLess strings)

Note: Path traversal test failure is environment-specific and unrelated to these changes.
Test results: 1142 pass, 4 skip, 1 fail (pre-existing path-traversal)

* Add QLoRA Processes tab with secure process management (#98)

- Fix iPhone Safari layout: vertical stacking on mobile, no horizontal overflow
- Add GET /api/v1/qlora/pids endpoint to list QLoRA processes
- Add POST /api/v1/qlora/kill endpoint with security constraints:
  - Deny-by-default for non-QLoRA processes
  - PID 1 and root daemon protection
  - UID ownership validation
  - SIGTERM-before-SIGKILL with 3s cooldown
- Add Processes UI tab with process table, PID input, confirmation modal
- Add security unit tests (5 tests)

Cherry-picked from dev branch commit b12ca6784

* Add session dropdown with archive/delete to Session header (#99)

- Add session dropdown selector showing current session name
- Display list of sessions with status indicator (green=active, gray=idle)
- Add archive (soft delete) button for each session in dropdown
- Add mobile-optimized delete button visible on small screens
- Confirmation modal before archiving
- Works without opening left panel - essential for iPhone Safari
- Uses existing sync.session.archive for soft delete
- Responsive: vertical stack on mobile, horizontal on desktop
- No horizontal scroll, tap targets >= 44px

Cherry-picked from dev branch commit e9dcd92a8

* feat: Add Simple Chat Provider Mode

* fix: Handle OpenRouter 404 'No endpoints found that support tool use' error (#101)

* feat(chat-mode): enforce Chat-only — strip agent/tool parts, block tool actions, add badge, tests

---------

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
