### PR TITLE
Remove bun cache workaround

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "openhei",

--- a/packages/openhei/src/bun/index.ts
+++ b/packages/openhei/src/bun/index.ts
@@ -7,7 +7,6 @@ import { NamedError } from "@openhei-ai/util/error"
 import { readableStreamToText } from "bun"
 import { Lock } from "../util/lock"
 import { PackageRegistry } from "./registry"
-import { proxied } from "@/util/proxied"
 
 export namespace BunProc {
   const log = Log.create({ service: "bun" })
@@ -92,8 +91,6 @@ export namespace BunProc {
       "add",
       "--force",
       "--exact",
-      // TODO: get rid of this case (see: https://github.com/oven-sh/bun/issues/19936)
-      ...(proxied() ? ["--no-cache"] : []),
       "--cwd",
       Global.Path.cache,
       pkg + "@" + version,

--- a/packages/openhei/src/config/config.ts
+++ b/packages/openhei/src/config/config.ts
@@ -31,7 +31,6 @@ import { GlobalBus } from "@/bus/global"
 import { Event } from "../server/event"
 import { Glob } from "../util/glob"
 import { PackageRegistry } from "@/bun/registry"
-import { proxied } from "@/util/proxied"
 import { iife } from "@/util/iife"
 import { Control } from "@/control"
 
@@ -324,8 +323,6 @@ export namespace Config {
     await BunProc.run(
       [
         "install",
-        // TODO: get rid of this case (see: https://github.com/oven-sh/bun/issues/19936)
-        ...(proxied() ? ["--no-cache"] : []),
       ],
       { cwd: dir },
     ).catch((err) => {

--- a/packages/openhei/src/util/proxied.ts
+++ b/packages/openhei/src/util/proxied.ts
@@ -1,3 +1,0 @@
-export function proxied() {
-  return !!(process.env.HTTP_PROXY || process.env.HTTPS_PROXY || process.env.http_proxy || process.env.https_proxy)
-}


### PR DESCRIPTION
- Removed the `--no-cache` fallback for proxied environments in `packages/openhei/src/bun/index.ts` and `packages/openhei/src/config/config.ts`.
- Deleted `packages/openhei/src/util/proxied.ts` as it is no longer used.
- Removed unused imports to `proxied` function.

---
*PR created automatically by Jules for task [2952012826443837965](https://jules.google.com/task/2952012826443837965) started by @heidi-dang*