### PR TITLE
fix(bun): remove --no-cache workaround in install command

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "openhei",

--- a/packages/openhei/src/bun/index.ts
+++ b/packages/openhei/src/bun/index.ts
@@ -7,7 +7,6 @@ import { NamedError } from "@openhei-ai/util/error"
 import { readableStreamToText } from "bun"
 import { Lock } from "../util/lock"
 import { PackageRegistry } from "./registry"
-import { proxied } from "@/util/proxied"
 
 export namespace BunProc {
   const log = Log.create({ service: "bun" })
@@ -92,8 +91,6 @@ export namespace BunProc {
       "add",
       "--force",
       "--exact",
-      // TODO: get rid of this case (see: https://github.com/oven-sh/bun/issues/19936)
-      ...(proxied() ? ["--no-cache"] : []),
       "--cwd",
       Global.Path.cache,
       pkg + "@" + version,


### PR DESCRIPTION
Fixes an issue where a workaround was applied for an old Bun cache bug. Since the upstream bug is resolved, the `--no-cache` argument and the dependency on the `proxied` utility have been removed from the bun installation command.

---
*PR created automatically by Jules for task [11185038451221276196](https://jules.google.com/task/11185038451221276196) started by @heidi-dang*