### PR TITLE
Persist permission ruleset

### DIFF
--- a/packages/openhei/src/permission/next.ts
+++ b/packages/openhei/src/permission/next.ts
@@ -224,10 +224,12 @@ export namespace PermissionNext {
           pending.resolve()
         }
 
-        // TODO: we don't save the permission ruleset to disk yet until there's
-        // UI to manage it
-        // db().insert(PermissionTable).values({ projectID: Instance.project.id, data: s.approved })
-        //   .onConflictDoUpdate({ target: PermissionTable.projectID, set: { data: s.approved } }).run()
+        Database.use((db) => {
+          db.insert(PermissionTable)
+            .values({ project_id: Instance.project.id, data: s.approved })
+            .onConflictDoUpdate({ target: PermissionTable.project_id, set: { data: s.approved } })
+            .run()
+        })
         return
       }
     },


### PR DESCRIPTION
Fixes an issue where user-approved permissions were not saved to the database by uncommenting and adjusting the insertion logic.

---
*PR created automatically by Jules for task [2574460487352790690](https://jules.google.com/task/2574460487352790690) started by @heidi-dang*