### PR TITLE
🧹 Handle context overflow error in session processor

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "openhei",

--- a/packages/openhei/src/session/processor.ts
+++ b/packages/openhei/src/session/processor.ts
@@ -354,27 +354,29 @@ export namespace SessionProcessor {
             })
             const error = MessageV2.fromError(e, { providerID: input.model.providerID })
             if (MessageV2.ContextOverflowError.isInstance(error)) {
-              // TODO: Handle context overflow error
-            }
-            const retry = SessionRetry.retryable(error)
-            if (retry !== undefined) {
-              attempt++
-              const delay = SessionRetry.delay(attempt, error.name === "APIError" ? error : undefined)
-              SessionStatus.set(input.sessionID, {
-                type: "retry",
-                attempt,
-                message: retry,
-                next: Date.now() + delay,
+              needsCompaction = true
+              input.assistantMessage.error = error
+            } else {
+              const retry = SessionRetry.retryable(error)
+              if (retry !== undefined) {
+                attempt++
+                const delay = SessionRetry.delay(attempt, error.name === "APIError" ? error : undefined)
+                SessionStatus.set(input.sessionID, {
+                  type: "retry",
+                  attempt,
+                  message: retry,
+                  next: Date.now() + delay,
+                })
+                await SessionRetry.sleep(delay, input.abort).catch(() => {})
+                continue
+              }
+              input.assistantMessage.error = error
+              Bus.publish(Session.Event.Error, {
+                sessionID: input.assistantMessage.sessionID,
+                error: input.assistantMessage.error,
               })
-              await SessionRetry.sleep(delay, input.abort).catch(() => {})
-              continue
+              SessionStatus.set(input.sessionID, { type: "idle" })
             }
-            input.assistantMessage.error = error
-            Bus.publish(Session.Event.Error, {
-              sessionID: input.assistantMessage.sessionID,
-              error: input.assistantMessage.error,
-            })
-            SessionStatus.set(input.sessionID, { type: "idle" })
           }
           if (snapshot) {
             const patch = await Snapshot.patch(snapshot)


### PR DESCRIPTION
🎯 **What:** Handled `ContextOverflowError` by triggering session compaction instead of ignoring the error or treating it as a generic API error.
💡 **Why:** When a context overflow occurs during an LLM stream, the processor previously fell back to generic `APIError` retry handling or fatal session termination. By explicitly setting `needsCompaction = true` and bypassing the standard retry logic, the system will accurately abort the current loop and return `"compact"` to properly reduce context size without breaking user flow or triggering a fatal `Session.Event.Error`.
✅ **Verification:** Ran test suite inside `packages/openhei`, no regressions were introduced. Evaluated changes through `request_code_review`.
✨ **Result:** A more resilient and intelligent conversational loop that handles context exhaustion cleanly.

---
*PR created automatically by Jules for task [17434511378444230617](https://jules.google.com/task/17434511378444230617) started by @heidi-dang*