### PR TITLE
fix(api): fail-soft changelog endpoint to prevent UI crash

### DIFF
--- a/packages/openhei/src/server/routes/global.ts
+++ b/packages/openhei/src/server/routes/global.ts
@@ -558,5 +558,43 @@ New config:`
           return c.json({ error: "Translation failed: " + msg }, 500)
         }
       },
+    )
+    .get(
+      "/changelog.json",
+      describeRoute({
+        summary: "Get changelog",
+        description: "Retrieve the OpenHei changelog/releases. Returns empty if not available.",
+        operationId: "global.changelog",
+        responses: {
+          200: {
+            description: "Changelog data",
+            content: {
+              "application/json": {
+                schema: resolver(z.any()),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        const changelogPaths = [
+          path.join(Global.Path.data, "changelog.json"),
+          path.join(Global.Path.home, "changelog.json"),
+          "./changelog.json",
+        ]
+        for (const changelogPath of changelogPaths) {
+          try {
+            if (existsSync(changelogPath)) {
+              const content = readFileSync(changelogPath, "utf-8")
+              const json = JSON.parse(content)
+              return c.json(json)
+            }
+          } catch {
+            // continue to next path
+          }
+        }
+        log.warn("changelog not found, returning empty")
+        return c.json({ items: [] })
+      },
     ),
 )


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes random UI crashes caused by unhandled fetch failures:

1. **Backend: changelog endpoint** - Added  endpoint that returns 200 with empty  if changelog file is missing, instead of returning 404/500 which was causing UI crashes.

2. **Backend: session route** - Already returns proper JSON error on 404 via NotFoundError handling (no changes needed).

### How did you verify my code works?

- Type checks pass on both packages
- Backend endpoint now returns 200 with empty payload when no changelog exists

### Screenshots / recordings

N/A - This is a backend fix

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---

## Evidence Pack

### Start Commands

```bash
# Start backend
cd packages/openhei && bun run --conditions=browser ./src/index.ts serve --port 4096

# Start app  
cd packages/app && bun dev -- --port 4444
```

### Repro Steps

1. Run app without a changelog.json file
2. Open UI - previously would crash on fetch failure
3. Now shows no crash, gracefully handles missing changelog

### Backend Logs

When changelog is missing, logs:
```
warn: changelog not found, returning empty
```

### Network Proof

- Changelog fetch now returns 200 with `{items:[]}` instead of 404/500

### Dev Report

Status: GOOD

Proof:
- Typechecks pass
- Endpoint returns 200 with empty payload on missing file
- Session 404 returns proper JSON error

Next: WAITING