### PR TITLE
fix(ui): remove unused import in ghost-code.tsx

### DIFF
--- a/packages/ui/src/components/ghost-code.tsx
+++ b/packages/ui/src/components/ghost-code.tsx
@@ -1,4 +1,4 @@
-import { Component, For, createMemo, Show } from "solid-js"
+import { Component, For, createMemo } from "solid-js"
 import "./ghost-code.css"
 
 export interface GhostCodeProps {


### PR DESCRIPTION
## Summary

Minor cleanup: removes unused `Show` import from ghost-code.tsx.

## Changes

- Remove unused `Show` import from ghost-code.tsx
- Skeleton fix already merged via PR #124

## Testing

- Typecheck passes for UI package
- Tests pass: `bun test` in packages/ui

## Evidence

- BiDi check: clean (no hidden unicode characters)
- All 5 skeleton files verified clean