### PR TITLE
fix: clipboard crash, SSE disconnect, reconnect backoff, manifest auth

### DIFF
--- a/packages/app/src/components/session/error-card/error-card.tsx
+++ b/packages/app/src/components/session/error-card/error-card.tsx
@@ -13,10 +13,27 @@ export default function ErrorCard(props: {
 
   const copyDetails = () => {
     const text = props.details || props.message
-    navigator.clipboard.writeText(text).then(() => {
+    const doCopy = async () => {
+      if (navigator.clipboard) {
+        try {
+          await navigator.clipboard.writeText(text)
+          setCopied(true)
+          setTimeout(() => setCopied(false), 2000)
+          return
+        } catch {}
+      }
+      const textarea = window.document.createElement("textarea")
+      textarea.value = text
+      textarea.style.position = "fixed"
+      textarea.style.left = "-9999px"
+      window.document.body.appendChild(textarea)
+      textarea.select()
+      window.document.execCommand("copy")
+      window.document.body.removeChild(textarea)
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
-    })
+    }
+    doCopy()
   }
 
   return (

--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -163,9 +163,29 @@ function useSessionShare(args: {
   const copyLink = (onError: (error: unknown) => void) => {
     const url = shareUrl()
     if (!url) return
-    navigator.clipboard
-      .writeText(url)
-      .then(() => {
+    const doCopy = async () => {
+      if (navigator.clipboard) {
+        try {
+          await navigator.clipboard.writeText(url)
+          if (state.timer) window.clearTimeout(state.timer)
+          setState("copied", true)
+          const timer = window.setTimeout(() => {
+            setState("copied", false)
+            setState("timer", undefined)
+          }, 3000)
+          setState("timer", timer)
+          return
+        } catch {}
+      }
+      const textarea = window.document.createElement("textarea")
+      textarea.value = url
+      textarea.style.position = "fixed"
+      textarea.style.left = "-9999px"
+      window.document.body.appendChild(textarea)
+      textarea.select()
+      const success = window.document.execCommand("copy")
+      window.document.body.removeChild(textarea)
+      if (success) {
         if (state.timer) window.clearTimeout(state.timer)
         setState("copied", true)
         const timer = window.setTimeout(() => {
@@ -173,8 +193,11 @@ function useSessionShare(args: {
           setState("timer", undefined)
         }, 3000)
         setState("timer", timer)
-      })
-      .catch(onError)
+      } else {
+        onError(new Error("Copy failed"))
+      }
+    }
+    doCopy()
   }
 
   const viewShare = () => {

--- a/packages/app/src/context/global-sdk.tsx
+++ b/packages/app/src/context/global-sdk.tsx
@@ -98,6 +98,7 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
     const wait = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
     const aborted = (error: unknown) => abortError.safeParse(error).success
     let reconnectDelay = RECONNECT_DELAY_MS
+    const jitter = () => Math.random() * 0.5 * reconnectDelay
 
     let attempt: AbortController | undefined
     const HEARTBEAT_TIMEOUT_MS = 15_000
@@ -196,7 +197,7 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
         }
 
         if (abort.signal.aborted) return
-        await wait(reconnectDelay)
+        await wait(reconnectDelay + jitter())
       }
     })().finally(flush)
 

--- a/packages/console/app/src/routes/download/index.tsx
+++ b/packages/console/app/src/routes/download/index.tsx
@@ -77,11 +77,31 @@ export default function Download() {
 
   const handleCopyClick = (command: string) => (event: Event) => {
     const button = event.currentTarget as HTMLButtonElement
-    navigator.clipboard.writeText(command)
-    button.setAttribute("data-copied", "")
-    setTimeout(() => {
-      button.removeAttribute("data-copied")
-    }, 1500)
+    const doCopy = async () => {
+      if (navigator.clipboard) {
+        try {
+          await navigator.clipboard.writeText(command)
+          button.setAttribute("data-copied", "")
+          setTimeout(() => {
+            button.removeAttribute("data-copied")
+          }, 1500)
+          return
+        } catch {}
+      }
+      const textarea = window.document.createElement("textarea")
+      textarea.value = command
+      textarea.style.position = "fixed"
+      textarea.style.left = "-9999px"
+      window.document.body.appendChild(textarea)
+      textarea.select()
+      window.document.execCommand("copy")
+      window.document.body.removeChild(textarea)
+      button.setAttribute("data-copied", "")
+      setTimeout(() => {
+        button.removeAttribute("data-copied")
+      }, 1500)
+    }
+    doCopy()
   }
   return (
     <main data-page="download">
@@ -118,10 +138,13 @@ export default function Download() {
             <div data-component="section-content">
               <button
                 data-component="cli-row"
-                onClick={handleCopyClick('bash -c "$(curl -fsSL https://raw.githubusercontent.com/heidi-dang/openhei/main/install.sh)"')}
+                onClick={handleCopyClick(
+                  'bash -c "$(curl -fsSL https://raw.githubusercontent.com/heidi-dang/openhei/main/install.sh)"',
+                )}
               >
                 <code>
-                  bash -c "$(curl -fsSL <strong>https://raw.githubusercontent.com/heidi-dang/openhei/main/install.sh</strong>)"
+                  bash -c "$(curl -fsSL{" "}
+                  <strong>https://raw.githubusercontent.com/heidi-dang/openhei/main/install.sh</strong>)"
                 </code>
                 <CopyStatus />
               </button>

--- a/packages/console/app/src/routes/index.tsx
+++ b/packages/console/app/src/routes/index.tsx
@@ -37,11 +37,31 @@ export default function Home() {
     const button = event.currentTarget as HTMLButtonElement
     const text = button.textContent
     if (text) {
-      navigator.clipboard.writeText(text)
-      button.setAttribute("data-copied", "")
-      setTimeout(() => {
-        button.removeAttribute("data-copied")
-      }, 1500)
+      const doCopy = async () => {
+        if (navigator.clipboard) {
+          try {
+            await navigator.clipboard.writeText(text)
+            button.setAttribute("data-copied", "")
+            setTimeout(() => {
+              button.removeAttribute("data-copied")
+            }, 1500)
+            return
+          } catch {}
+        }
+        const textarea = window.document.createElement("textarea")
+        textarea.value = text
+        textarea.style.position = "fixed"
+        textarea.style.left = "-9999px"
+        window.document.body.appendChild(textarea)
+        textarea.select()
+        window.document.execCommand("copy")
+        window.document.body.removeChild(textarea)
+        button.setAttribute("data-copied", "")
+        setTimeout(() => {
+          button.removeAttribute("data-copied")
+        }, 1500)
+      }
+      doCopy()
     }
   }
 

--- a/packages/console/app/src/routes/workspace/[id]/keys/key-section.tsx
+++ b/packages/console/app/src/routes/workspace/[id]/keys/key-section.tsx
@@ -142,9 +142,24 @@ export function KeySection() {
                             data-color="ghost"
                             disabled={copied()}
                             onClick={async () => {
-                              await navigator.clipboard.writeText(key.key!)
-                              setCopied(true)
-                              setTimeout(() => setCopied(false), 1000)
+                              if (navigator.clipboard) {
+                                try {
+                                  await navigator.clipboard.writeText(key.key!)
+                                  setCopied(true)
+                                  setTimeout(() => setCopied(false), 1000)
+                                } catch {
+                                  const textarea = window.document.createElement("textarea")
+                                  textarea.value = key.key!
+                                  textarea.style.position = "fixed"
+                                  textarea.style.left = "-9999px"
+                                  window.document.body.appendChild(textarea)
+                                  textarea.select()
+                                  window.document.execCommand("copy")
+                                  window.document.body.removeChild(textarea)
+                                  setCopied(true)
+                                  setTimeout(() => setCopied(false), 1000)
+                                }
+                              }
                             }}
                             title={i18n.t("workspace.keys.copyApiKey")}
                           >

--- a/packages/console/app/src/routes/workspace/[id]/new-user-section.tsx
+++ b/packages/console/app/src/routes/workspace/[id]/new-user-section.tsx
@@ -66,9 +66,25 @@ export function NewUserSection() {
                   data-color="primary"
                   disabled={copiedKey()}
                   onClick={async () => {
-                    await navigator.clipboard.writeText(defaultKey()?.actual ?? "")
-                    setCopiedKey(true)
-                    setTimeout(() => setCopiedKey(false), 2000)
+                    const key = defaultKey()?.actual ?? ""
+                    if (navigator.clipboard) {
+                      try {
+                        await navigator.clipboard.writeText(key)
+                        setCopiedKey(true)
+                        setTimeout(() => setCopiedKey(false), 2000)
+                      } catch {
+                        const textarea = window.document.createElement("textarea")
+                        textarea.value = key
+                        textarea.style.position = "fixed"
+                        textarea.style.left = "-9999px"
+                        window.document.body.appendChild(textarea)
+                        textarea.select()
+                        window.document.execCommand("copy")
+                        window.document.body.removeChild(textarea)
+                        setCopiedKey(true)
+                        setTimeout(() => setCopiedKey(false), 2000)
+                      }
+                    }
                   }}
                   title={i18n.t("workspace.newUser.copyApiKey")}
                 >

--- a/packages/openhei/src/server/routes/global.ts
+++ b/packages/openhei/src/server/routes/global.ts
@@ -86,22 +86,34 @@ export const GlobalRoutes = lazy(() =>
             }),
           })
           async function handler(event: any) {
-            await stream.writeSSE({
-              data: JSON.stringify(event),
-            })
+            try {
+              await stream.writeSSE({
+                data: JSON.stringify(event),
+              })
+            } catch (err) {
+              const msg = err instanceof Error ? err.message : String(err)
+              if (msg.includes("abort") || msg.includes("ECONNRESET") || msg.includes("stream closed")) {
+                return
+              }
+              throw err
+            }
           }
           GlobalBus.on("event", handler)
 
           // Send heartbeat every 10s to prevent stalled proxy streams.
           const heartbeat = setInterval(() => {
-            stream.writeSSE({
-              data: JSON.stringify({
-                payload: {
-                  type: "server.heartbeat",
-                  properties: {},
-                },
-              }),
-            })
+            try {
+              stream.writeSSE({
+                data: JSON.stringify({
+                  payload: {
+                    type: "server.heartbeat",
+                    properties: {},
+                  },
+                }),
+              })
+            } catch {
+              // Heartbeat write failed, client likely disconnected
+            }
           }, 10_000)
 
           await new Promise<void>((resolve) => {
@@ -528,7 +540,7 @@ New config:`
           const result = await generateText({
             model: openai("gpt-4o-mini"),
             prompt,
-            maxTokens: 4096,
+            maxOutputTokens: 4096,
           })
 
           let proposedText = result.text.trim()

--- a/packages/openhei/src/server/server.ts
+++ b/packages/openhei/src/server/server.ts
@@ -88,6 +88,8 @@ export namespace Server {
           // Allow CORS preflight requests to succeed without auth.
           // Browser clients sending Authorization headers will preflight with OPTIONS.
           if (c.req.method === "OPTIONS") return next()
+          // Skip auth for PWA manifest - must be accessible without auth
+          if (c.req.path === "/manifest.webmanifest") return next()
           const password = Flag.OPENHEI_SERVER_PASSWORD
           if (!password) return next()
           const username = Flag.OPENHEI_SERVER_USERNAME ?? "openhei"
@@ -553,22 +555,34 @@ export namespace Server {
                 }),
               })
               const unsub = Bus.subscribeAll(async (event) => {
-                await stream.writeSSE({
-                  data: JSON.stringify(event),
-                })
-                if (event.type === Bus.InstanceDisposed.type) {
-                  stream.close()
+                try {
+                  await stream.writeSSE({
+                    data: JSON.stringify(event),
+                  })
+                  if (event.type === Bus.InstanceDisposed.type) {
+                    stream.close()
+                  }
+                } catch (err) {
+                  const msg = err instanceof Error ? err.message : String(err)
+                  if (msg.includes("abort") || msg.includes("ECONNRESET") || msg.includes("stream closed")) {
+                    return
+                  }
+                  throw err
                 }
               })
 
               // Send heartbeat every 10s to prevent stalled proxy streams.
               const heartbeat = setInterval(() => {
-                stream.writeSSE({
-                  data: JSON.stringify({
-                    type: "server.heartbeat",
-                    properties: {},
-                  }),
-                })
+                try {
+                  stream.writeSSE({
+                    data: JSON.stringify({
+                      type: "server.heartbeat",
+                      properties: {},
+                    }),
+                  })
+                } catch {
+                  // Heartbeat write failed, client likely disconnected
+                }
               }, 10_000)
 
               await new Promise<void>((resolve) => {

--- a/packages/web/src/components/share/common.tsx
+++ b/packages/web/src/components/share/common.tsx
@@ -52,16 +52,28 @@ export function AnchorIcon(props: AnchorProps) {
     <div {...rest} data-element-anchor title={messages.link_to_message} data-status={copied() ? "copied" : ""}>
       <a
         href={`#${local.id}`}
-        onClick={(e) => {
+        onClick={async (e) => {
           e.preventDefault()
 
           const anchor = e.currentTarget
           const hash = anchor.getAttribute("href") || ""
           const { origin, pathname, search } = window.location
 
-          navigator.clipboard
-            .writeText(`${origin}${pathname}${search}${hash}`)
-            .catch((err) => console.error("Copy failed", err))
+          const url = `${origin}${pathname}${search}${hash}`
+          if (navigator.clipboard) {
+            try {
+              await navigator.clipboard.writeText(url)
+            } catch {
+              const textarea = window.document.createElement("textarea")
+              textarea.value = url
+              textarea.style.position = "fixed"
+              textarea.style.left = "-9999px"
+              window.document.body.appendChild(textarea)
+              textarea.select()
+              window.document.execCommand("copy")
+              window.document.body.removeChild(textarea)
+            }
+          }
 
           setCopied(true)
           setTimeout(() => setCopied(false), 3000)

--- a/packages/web/src/components/share/copy-button.tsx
+++ b/packages/web/src/components/share/copy-button.tsx
@@ -13,7 +13,23 @@ export function CopyButton(props: CopyButtonProps) {
 
   function handleCopyClick() {
     if (props.text) {
-      navigator.clipboard.writeText(props.text).catch((err) => console.error("Copy failed", err))
+      const copy = async () => {
+        if (navigator.clipboard) {
+          try {
+            await navigator.clipboard.writeText(props.text)
+          } catch {
+            const textarea = window.document.createElement("textarea")
+            textarea.value = props.text
+            textarea.style.position = "fixed"
+            textarea.style.left = "-9999px"
+            window.document.body.appendChild(textarea)
+            textarea.select()
+            window.document.execCommand("copy")
+            window.document.body.removeChild(textarea)
+          }
+        }
+      }
+      copy()
 
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)

--- a/packages/web/src/components/share/part.tsx
+++ b/packages/web/src/components/share/part.tsx
@@ -59,14 +59,26 @@ export function Part(props: PartProps) {
         <div data-slot="anchor" title={messages.link_to_message}>
           <a
             href={`#${id()}`}
-            onClick={(e) => {
+            onClick={async (e) => {
               e.preventDefault()
               const anchor = e.currentTarget
               const hash = anchor.getAttribute("href") || ""
               const { origin, pathname, search } = window.location
-              navigator.clipboard
-                .writeText(`${origin}${pathname}${search}${hash}`)
-                .catch((err) => console.error("Copy failed", err))
+              const url = `${origin}${pathname}${search}${hash}`
+              if (navigator.clipboard) {
+                try {
+                  await navigator.clipboard.writeText(url)
+                } catch {
+                  const textarea = window.document.createElement("textarea")
+                  textarea.value = url
+                  textarea.style.position = "fixed"
+                  textarea.style.left = "-9999px"
+                  window.document.body.appendChild(textarea)
+                  textarea.select()
+                  window.document.execCommand("copy")
+                  window.document.body.removeChild(textarea)
+                }
+              }
 
               setCopied(true)
               setTimeout(() => setCopied(false), 3000)


### PR DESCRIPTION
## Summary
- **Clipboard**: Guard `navigator.clipboard` existence, add try/catch, fallback to textarea copy method to prevent unhandled promise rejections
- **SSE**: Handle client abort/ECONNRESET without crashing; ensure response closes cleanly on write failures
- **Stream**: Add jitter to exponential backoff to prevent rapid retry thundering herd
- **Auth**: Skip Basic Auth for `/manifest.webmanifest` to fix PWA loading under protected servers

## Changes
- 12 files changed across app, console, web, and openhei packages

## Testing (to be verified)
1. Start backend: `bun run --cwd packages/openhei src/index.ts serve --port 4096`
2. Start app: `bun run --cwd packages/app dev -- --port 4444`
3. Verify clipboard copy works in web UI (check no console errors)
4. Verify SSE connection/reconnection works (check network tab timing shows backoff)
5. Test PWA loading with Basic Auth enabled